### PR TITLE
Remove Infinite an non-number results from decimal-typed generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.1.0 / 2022 Jul 24
+
+> This release improves the generators for decimal types to restrict ##NaN and ##Inf from being created
+
+* **Update** - Improve generators for decimal typed fields
+
 ## v2.0.0 / 2022 Jul 10
 
 > **BREAKING:** This release bifurcates the three separate utilities this library was responsible into discrete libraries. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-beer-format",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common-beer-format",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "devDependencies": {
         "karma": "^6.3.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-beer-format",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "An implementation  of the BeerXML spec in multiple formats",
   "main": "index.js",
   "directories": {

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject com.wallbrew/common-beer-format "2.0.0"
+(defproject com.wallbrew/common-beer-format "2.1.0"
   :description "An implementation of the BeerXML spec in multiple formats"
   :url "https://github.com/Wall-Brew-Co/common-beer-format"
   :license {:name "MIT"
             :url  "https://opensource.org/licenses/MIT"}
   :dependencies [[metosin/spec-tools "0.10.5"]
-                 [nnichols "1.0.0"]
+                 [nnichols "1.1.0"]
                  [org.clojure/clojure "1.11.1"]
                  [org.clojure/clojurescript "1.11.60" :scope "provided"]
                  [org.clojure/data.json "2.4.0"]

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-format.equipment
   "The definition of an equipment record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
+            [clojure.test.check.generators :as gen]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -42,6 +43,7 @@
   (st/spec
     {:type                :double
      :spec                (s/and number? #(not (neg? %)))
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius"
      :json-schema/example "0.2"}))
 

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -34,12 +34,12 @@
 
 (s/def ::color
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable"
-    :json-schema/example "32"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable"
+     :json-schema/example "32"}))
 
 
 (s/def ::add-after-boil
@@ -80,13 +80,13 @@
 
 (s/def ::diastatic-power
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         (str "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.\n"
-                              "Only appropriate for the 'Grain' or 'Adjunct' types.")
-    :json-schema/example "0.65"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         (str "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.\n"
+                               "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example "0.65"}))
 
 
 (s/def ::protein
@@ -94,7 +94,7 @@
     {:type                :double
      :spec                ::prim/percent
      :description         (str "A non-negative IEEE-754 floating point number representing the protein contents of the grain.\n"
-                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
+                               "Only appropriate for the 'Grain' or 'Adjunct' types.")
      :json-schema/example "0.10"}))
 
 
@@ -108,24 +108,24 @@
 
 (s/def ::recommend-mash
   (st/spec
-   {:spec                ::prim/boolean
-    :description         (str "A boolean representing if the fermentable is recommended to be included in the mashing step.\n"
-                              "Only appropriate for the 'Grain' or 'Adjunct' types.\n"
-                              "When absent, assume false.")
-    :json-schema/example "false"
-    :decode/string       util/decode-boolean
-    :encode/string       util/encode-boolean}))
+    {:spec                ::prim/boolean
+     :description         (str "A boolean representing if the fermentable is recommended to be included in the mashing step.\n"
+                               "Only appropriate for the 'Grain' or 'Adjunct' types.\n"
+                               "When absent, assume false.")
+     :json-schema/example "false"
+     :decode/string       util/decode-boolean
+     :encode/string       util/encode-boolean}))
 
 
 (s/def ::ibu-gal-per-lb
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         (str "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.\n"
-                              "Only appropriate for the 'Extract' type.")
-    :json-schema/example "12.5"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         (str "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.\n"
+                               "Only appropriate for the 'Extract' type.")
+     :json-schema/example "12.5"}))
 
 
 (s/def ::potential

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -1,7 +1,8 @@
 (ns common-beer-format.fermentables
   "The definition of a fermentable record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
+            [clojure.test.check.generators :as gen]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -15,8 +16,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? fermentable-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? fermentable-types (str/lower-case %)))
      :gen                 #(s/gen fermentable-types)
      :description         "A case-insensitive string representing the form of the fermentable.
                           Must be one of: 'Grain', 'Sugar', 'Extract', 'Dry Extract', and 'Adjunct'"
@@ -33,10 +34,12 @@
 
 (s/def ::color
   (st/spec
-    {:type                :double
-     :spec                number?
-     :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable"
-     :json-schema/example "32"}))
+   {:type                :double
+    :spec                number?
+    :gen                 #(gen/double* {:infinite? false
+                                        :NaN?      false})
+    :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable"
+    :json-schema/example "32"}))
 
 
 (s/def ::add-after-boil
@@ -77,19 +80,21 @@
 
 (s/def ::diastatic-power
   (st/spec
-    {:type                :double
-     :spec                number?
-     :description         "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.
-                          Only appropriate for the 'Grain' or 'Adjunct' types."
-     :json-schema/example "0.65"}))
+   {:type                :double
+    :spec                number?
+    :gen                 #(gen/double* {:infinite? false
+                                        :NaN?      false})
+    :description         (str "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.\n"
+                              "Only appropriate for the 'Grain' or 'Adjunct' types.")
+    :json-schema/example "0.65"}))
 
 
 (s/def ::protein
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the protein contents of the grain.
-                          Only appropriate for the 'Grain' or 'Adjunct' types."
+     :description         (str "A non-negative IEEE-754 floating point number representing the protein contents of the grain.\n"
+                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
      :json-schema/example "0.10"}))
 
 
@@ -103,22 +108,24 @@
 
 (s/def ::recommend-mash
   (st/spec
-    {:spec                ::prim/boolean
-     :description         "A boolean representing if the fermentable is recommended to be included in the mashing step.
-                          Only appropriate for the 'Grain' or 'Adjunct' types.
-                          When absent, assume false."
-     :json-schema/example "false"
-     :decode/string       util/decode-boolean
-     :encode/string       util/encode-boolean}))
+   {:spec                ::prim/boolean
+    :description         (str "A boolean representing if the fermentable is recommended to be included in the mashing step.\n"
+                              "Only appropriate for the 'Grain' or 'Adjunct' types.\n"
+                              "When absent, assume false.")
+    :json-schema/example "false"
+    :decode/string       util/decode-boolean
+    :encode/string       util/encode-boolean}))
 
 
 (s/def ::ibu-gal-per-lb
   (st/spec
-    {:type                :double
-     :spec                number?
-     :description         "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.
-                          Only appropriate for the 'Extract' type."
-     :json-schema/example "12.5"}))
+   {:type                :double
+    :spec                number?
+    :gen                 #(gen/double* {:infinite? false
+                                        :NaN?      false})
+    :description         (str "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.\n"
+                              "Only appropriate for the 'Extract' type.")
+    :json-schema/example "12.5"}))
 
 
 (s/def ::potential

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -1,7 +1,7 @@
 (ns common-beer-format.hops
   "The definition of a hop record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -23,8 +23,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? hop-uses (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? hop-uses (str/lower-case %)))
      :gen                 #(s/gen hop-uses)
      :description         "A case-insensitive string representing the means by which the hop is added to the beer.
                           Must be one of: 'Boil', 'Dry Hop', 'Mash', 'First Wort', and 'Aroma'"
@@ -33,15 +33,16 @@
 
 (s/def ::time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field.
-                          For \"Boil\" this is the boil time.
-                          For \"Mash\" this is the mash time.
-                          For \"First Wort\" this is the boil time.
-                          For \"Aroma\" this is the steep time.
-                          For \"Dry Hop\" this is the amount of time to dry hop."
-     :json-schema/example "15.0"}))
+   {:type                :double
+    :spec                ::prim/minute
+    :description         (str/join "\n"
+                                   ["A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
+                                    "For \"Boil\" this is the boil time."
+                                    "For \"Mash\" this is the mash time."
+                                    "For \"First Wort\" this is the boil time."
+                                    "For \"Aroma\" this is the steep time."
+                                    "For \"Dry Hop\" this is the amount of time to dry hop."])
+    :json-schema/example "15.0"}))
 
 
 (def ^:const hop-types
@@ -52,8 +53,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? hop-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? hop-types (str/lower-case %)))
      :gen                 #(s/gen hop-types)
      :description         "A case-insensitive string representing the means by which the hop is added to the beer.
                           Must be one of: 'Bittering', 'Aroma', and 'Both'"
@@ -68,8 +69,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? hop-forms (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? hop-forms (str/lower-case %)))
      :gen #(s/gen hop-forms)
      :description         "A case-insensitive string representing the from of the hop added to the beer.
                           Must be one of: 'Pellet', 'Plug' or 'Leaf'"

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -33,16 +33,16 @@
 
 (s/def ::time
   (st/spec
-   {:type                :double
-    :spec                ::prim/minute
-    :description         (str/join "\n"
-                                   ["A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
-                                    "For \"Boil\" this is the boil time."
-                                    "For \"Mash\" this is the mash time."
-                                    "For \"First Wort\" this is the boil time."
-                                    "For \"Aroma\" this is the steep time."
-                                    "For \"Dry Hop\" this is the amount of time to dry hop."])
-    :json-schema/example "15.0"}))
+    {:type                :double
+     :spec                ::prim/minute
+     :description         (str/join "\n"
+                                    ["A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
+                                     "For \"Boil\" this is the boil time."
+                                     "For \"Mash\" this is the mash time."
+                                     "For \"First Wort\" this is the boil time."
+                                     "For \"Aroma\" this is the steep time."
+                                     "For \"Dry Hop\" this is the amount of time to dry hop."])
+     :json-schema/example "15.0"}))
 
 
 (def ^:const hop-types

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -1,7 +1,7 @@
 (ns common-beer-format.mash
   "The definition of mash steps and the mash profile records used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -15,8 +15,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? mash-step-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? mash-step-types (str/lower-case %)))
      :gen #(s/gen mash-step-types)
      :description         "A case-insensitive string representing the type of mash step.
                           Must be one of: 'Infusion', 'Temperature', and 'Decoction'"

--- a/src/common_beer_format/miscs.cljc
+++ b/src/common_beer_format/miscs.cljc
@@ -1,7 +1,7 @@
 (ns common-beer-format.miscs
   "The definition of a misc record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -15,8 +15,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? misc-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? misc-types (str/lower-case %)))
      :gen #(s/gen misc-types)
      :description         "A case-insensitive string representing the type of the miscellaneous item added to the beer.
                           Must be one of: 'Spice', 'Fining', 'Water Agent', 'Herb', 'Flavor', and 'Other'"
@@ -31,8 +31,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? misc-uses (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? misc-uses (str/lower-case %)))
      :gen                #(s/gen misc-uses)
      :description         "A case-insensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer.
                           Must be one of: 'Boil', 'Mash', 'Primary', 'Secondary', and 'Bottling'"

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -1,16 +1,17 @@
 (ns common-beer-format.primitives
   "The basic definitions, units, etc. used in BeerXML"
   (:require [clojure.spec.alpha :as s]
+            [clojure.test.check.generators :as gen]
             [clojure.string :as cs]
             [common-beer-format.util :as util]
             [nnichols.predicate :as np]
             [spec-tools.core :as st]))
 
-
 (s/def ::kilogram
   (st/spec
     {:type                :double
      :spec                (s/and number? #(not (neg? %)))
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A non-negative IEEE-754 floating point number representing weight in kilograms"
      :json-schema/example "10.7"}))
 
@@ -19,6 +20,7 @@
   (st/spec
     {:type                :double
      :spec                (s/and number? #(not (neg? %)))
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A non-negative IEEE-754 floating point number representing volume in liters"
      :json-schema/example "12.3"}))
 
@@ -27,6 +29,7 @@
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false :NaN? false})
      :description         "An IEEE-754 floating point number representing degress in Celsius"
      :json-schema/example "-10.7"}))
 
@@ -35,6 +38,7 @@
   (st/spec
     {:type                :double
      :spec                (s/and number? #(not (neg? %)))
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A non-negative IEEE-754 floating point number representing time in minutes"
      :json-schema/example "45.0"}))
 
@@ -43,6 +47,7 @@
   (st/spec
     {:type                :double
      :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water"
      :json-schema/example "1.045"}))
 
@@ -51,6 +56,7 @@
   (st/spec
     {:type                :double
      :spec                (s/and number? #(not (neg? %)))
+     :gen                 #(gen/double* {:infinite? false :NaN? false :min 0})
      :description         "A non-negative IEEE-754 floating point number representing pressure in kilopascals"
      :json-schema/example "101.325"}))
 
@@ -59,6 +65,7 @@
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false :NaN? false})
      :description         "An IEEE-754 floating point number representing a human-readable percentage - e.g 5.5"
      :json-schema/example "4.5"}))
 

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -7,6 +7,7 @@
             [nnichols.predicate :as np]
             [spec-tools.core :as st]))
 
+
 (s/def ::kilogram
   (st/spec
     {:type                :double

--- a/src/common_beer_format/recipes.cljc
+++ b/src/common_beer_format/recipes.cljc
@@ -22,14 +22,14 @@
 
 (s/def ::type
   (st/spec
-   {:type                :string
-    :spec                (s/and string?
-                                #(not (str/blank? %))
-                                #(contains? recipe-types (str/lower-case %)))
-    :gen                 #(s/gen recipe-types)
-    :description         (str "A case-insensitive string representing the type of recipe.\n"
-                              "Must be one of: 'Extract', 'Partial Mash', and 'All Grain'")
-    :json-schema/example "All Grain"}))
+    {:type                :string
+     :spec                (s/and string?
+                                 #(not (str/blank? %))
+                                 #(contains? recipe-types (str/lower-case %)))
+     :gen                 #(s/gen recipe-types)
+     :description         (str "A case-insensitive string representing the type of recipe.\n"
+                               "Must be one of: 'Extract', 'Partial Mash', and 'All Grain'")
+     :json-schema/example "All Grain"}))
 
 
 (s/def ::brewer
@@ -90,12 +90,12 @@
 
 (s/def ::taste-rating
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "An IEEE-754 floating point number representing the tasting score of the beer"
-    :json-schema/example "100.0"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "An IEEE-754 floating point number representing the tasting score of the beer"
+     :json-schema/example "100.0"}))
 
 
 (s/def ::og
@@ -209,12 +209,12 @@
 
 (s/def ::carbonation
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2"
-    :json-schema/example "1.5"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2"
+     :json-schema/example "1.5"}))
 
 
 (s/def ::forced-carbonation
@@ -245,22 +245,22 @@
 
 (s/def ::priming-sugar-equiv
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar"
-    :json-schema/example "1.5"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar"
+     :json-schema/example "1.5"}))
 
 
 (s/def ::keg-priming-factor
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
-    :json-schema/example "1.5"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
+     :json-schema/example "1.5"}))
 
 
 (s/def ::est-og

--- a/src/common_beer_format/styles.cljc
+++ b/src/common_beer_format/styles.cljc
@@ -1,7 +1,8 @@
 (ns common-beer-format.styles
   "The definition of a style record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
+            [clojure.test.check.generators :as gen]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -48,8 +49,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? style-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? style-types (str/lower-case %)))
      :gen #(s/gen style-types)
      :description         "A case-insensitive string representing the type of beverage the style dictates.
                           Must be one of: 'Lager', 'Ale', 'Mead', 'Wheat', 'Mixed', and 'Cider'"
@@ -90,24 +91,30 @@
 
 (s/def ::ibu-min
   (st/spec
-    {:type                :double
-     :spec                number?
-     :description         "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style"
-     :json-schema/example "32"}))
+   {:type                :double
+    :spec                number?
+    :gen                 #(gen/double* {:infinite? false
+                                        :NaN?      false})
+    :description         "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style"
+    :json-schema/example "32"}))
 
 
 (s/def ::ibu-max
   (st/spec
-    {:type                :double
-     :spec                number?
-     :description         "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style"
-     :json-schema/example "40"}))
+   {:type                :double
+    :spec                number?
+    :gen                 #(gen/double* {:infinite? false
+                                        :NaN?      false})
+    :description         "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style"
+    :json-schema/example "40"}))
 
 
 (s/def ::color-min
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
      :description         "A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style"
      :json-schema/example "32"}))
 
@@ -116,6 +123,8 @@
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
      :description         "A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style"
      :json-schema/example "40"}))
 
@@ -124,6 +133,8 @@
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
      :description         "A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2"
      :json-schema/example "1.5"}))
 
@@ -132,6 +143,8 @@
   (st/spec
     {:type                :double
      :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
      :description         "A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2"
      :json-schema/example "2.2"}))
 

--- a/src/common_beer_format/styles.cljc
+++ b/src/common_beer_format/styles.cljc
@@ -91,22 +91,22 @@
 
 (s/def ::ibu-min
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style"
-    :json-schema/example "32"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style"
+     :json-schema/example "32"}))
 
 
 (s/def ::ibu-max
   (st/spec
-   {:type                :double
-    :spec                number?
-    :gen                 #(gen/double* {:infinite? false
-                                        :NaN?      false})
-    :description         "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style"
-    :json-schema/example "40"}))
+    {:type                :double
+     :spec                number?
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false})
+     :description         "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style"
+     :json-schema/example "40"}))
 
 
 (s/def ::color-min

--- a/src/common_beer_format/util.cljc
+++ b/src/common_beer_format/util.cljc
@@ -1,6 +1,6 @@
 (ns ^:no-doc common-beer-format.util
   "Utility functions common to translation"
-  (:require [clojure.string :as cs]
+  (:require [clojure.string :as str]
             [nnichols.parse :as n-parse]
             [spec-tools.core :as st]))
 
@@ -18,7 +18,7 @@
 (defn encode-boolean
   "Encode a boolean into an XML-like Boolean string"
   [_spec value]
-  (-> value str cs/upper-case))
+  (-> value str str/upper-case))
 
 
 (defn decode-sequence

--- a/src/common_beer_format/waters.cljc
+++ b/src/common_beer_format/waters.cljc
@@ -1,6 +1,7 @@
 (ns common-beer-format.waters
   "The definition of a water record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
+            [clojure.test.check.generators :as gen]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -9,7 +10,10 @@
 (s/def ::calcium
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -17,7 +21,10 @@
 (s/def ::bicarbonate
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -25,7 +32,10 @@
 (s/def ::sulfate
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -33,7 +43,10 @@
 (s/def ::chloride
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -41,7 +54,10 @@
 (s/def ::sodium
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -49,7 +65,10 @@
 (s/def ::magnesium
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million"
      :json-schema/example "2.5"}))
 
@@ -57,7 +76,10 @@
 (s/def ::ph
   (st/spec
     {:type                :double
-     :spec                number?
+     :spec                (s/and number? pos?)
+     :gen                 #(gen/double* {:infinite? false
+                                         :NaN?      false
+                                         :min       0})
      :description         "A positive IEEE-754 floating point number representing the PH of the water"
      :json-schema/example "2.5"}))
 

--- a/src/common_beer_format/yeasts.cljc
+++ b/src/common_beer_format/yeasts.cljc
@@ -1,7 +1,7 @@
 (ns common-beer-format.yeasts
   "The definition of a yeast record used in BeerXML"
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as cs]
+            [clojure.string :as str]
             [common-beer-format.primitives :as prim]
             [common-beer-format.util :as util]
             [spec-tools.core :as st]))
@@ -15,8 +15,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? yeast-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? yeast-types (str/lower-case %)))
      :gen #(s/gen yeast-types)
      :description         "A case-insensitive string representing the type of yeast added to the beer.
                           Must be one of: 'Ale', 'Lager', 'Wheat', 'Wine', and 'Champagne'"
@@ -31,8 +31,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? yeast-forms (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? yeast-forms (str/lower-case %)))
      :gen #(s/gen yeast-forms)
      :description         "A case-insensitive string representing the form of the yeast added to the beer.
                           Must be one of: 'Liquid', 'Dry', 'Slant', and 'Culture'"
@@ -79,8 +79,8 @@
   (st/spec
     {:type                :string
      :spec                (s/and string?
-                                 #(not (cs/blank? %))
-                                 #(contains? yeast-flocculation-types (cs/lower-case %)))
+                                 #(not (str/blank? %))
+                                 #(contains? yeast-flocculation-types (str/lower-case %)))
      :gen #(s/gen yeast-flocculation-types)
      :description         "A case-insensitive string representing how dense of a floc the yeast will form.
                           Must be one of: 'Low', 'Medium', 'High', and 'Very High'"


### PR DESCRIPTION
# Changes proposed in this merge request

- Updates: This release improves the generators for decimal types to restrict ##NaN and ##Inf from being created

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update documentation
- [x] Update CHANGELOG and increment version

Fixes: https://github.com/Wall-Brew-Co/common-beer-format/issues/58