### PR TITLE
Publish Spec Documentation

### DIFF
--- a/.sealog/changes/2-3-0.edn
+++ b/.sealog/changes/2-3-0.edn
@@ -1,0 +1,15 @@
+{:version      {:major 2
+                :minor 3
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["Documentation generation from specs to markdown."]
+                :changed    ["Specs now carry metadata indicating the BeerXML Types and Units they are associated with."
+                             "Specs may contain metadata to render human friendly names for abbreviated fields."
+                             "List specs are tightened to only allow valid BeerXML units and types."
+                             "Symbols have been added for all legal values for BeerXML List types. For example: `common-beer-format.miscs/boil`."]
+                :deprecated []
+                :removed    ["Data (de)serialization dependencies (`clojure.data.xml`, `clojure.data.json`) leftover from `clj-xml`'s promotion to a standalone library have been removed."
+                             "Data generation dependencies (`clojure.test.check`) have been removed."]
+                :fixed      []
+                :security   []}
+ :timestamp    "2024-03-17T20:16:43.988162Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [2.3.0 - 2024-03-17](#230---2024-03-17)
 * [2.2.2 - 2024-03-10](#222---2024-03-10)
 * [2.2.1 - 2023-02-12](#221---2023-02-12)
 * [2.2.0 - 2023-02-09](#220---2023-02-09)
@@ -18,6 +19,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [1.1.0 - 2020-05-08](#110---2020-05-08)
 * [1.0.0 - 2020-05-05](#100---2020-05-05)
 * [0.0.0 - 2020-03-17](#000---2020-03-17)
+
+## 2.3.0 - 2024-03-17
+
+* Added
+  * Documentation generation from specs to markdown.
+* Changed
+  * Specs now carry metadata indicating the BeerXML Types and Units they are associated with.
+  * Specs may contain metadata to render human friendly names for abbreviated fields.
+  * List specs are tightened to only allow valid BeerXML units and types.
+  * Symbols have been added for all legal values for BeerXML List types. For example: `common-beer-format.miscs/boil`.
+* Removed
+  * Data (de)serialization dependencies (`clojure.data.xml`, `clojure.data.json`) leftover from `clj-xml`'s promotion to a standalone library have been removed.
+  * Data generation dependencies (`clojure.test.check`) have been removed.
 
 ## 2.2.2 - 2024-03-10
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ version/major:
 	@ lein change version leiningen.release/bump-version release
 	@ lein sealog bump major
 	@ lein pom
+	@ lein export-specs
 
 version/minor:
 	$(info Updating minor version and adding CHANGELOG entry...)
@@ -22,6 +23,7 @@ version/minor:
 	@ lein change version leiningen.release/bump-version release
 	@ lein sealog bump minor
 	@ lein pom
+	@ lein export-specs
 
 version/patch:
 	$(info Updating patch version and adding CHANGELOG entry...)
@@ -30,6 +32,7 @@ version/patch:
 	@ lein change version leiningen.release/bump-version release
 	@ lein sealog bump patch
 	@ lein pom
+	@ lein export-specs
 
 changelog/render:
 	$(info Rendering CHANGELOG...)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # common-beer-format
 
 [![Clojars Project](https://img.shields.io/clojars/v/com.wallbrew/common-beer-format.svg)](https://clojars.org/com.wallbrew/common-beer-format)
-![GitHub Runner](https://github.com/Wall-Brew-Co/common-beer-format/workflows/Clojurescript%20CI/badge.svg)
+[![cljdoc badge](https://cljdoc.org/badge/com.wallbrew/common-beer-format)](https://cljdoc.org/d/com.wallbrew/common-beer-format/CURRENT)
+[![GitHub](https://img.shields.io/github/license/Wall-Brew-Co/common-beer-format)](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/LICENSE)
+[![Twitter Follow](https://img.shields.io/twitter/follow/WallBrew?style=social)](https://twitter.com/WallBrew)
 
 A Clojure(Script) implementation of the [BeerXML 1.0 schema](http://www.beerxml.com/) with cross-format support using Metosin's [spec-tools.](https://github.com/metosin/spec-tools)
 The library endeavors to support the data specification as a [clojure spec](https://clojure.org/about/spec) and includes all optional fields in the core BeerXML spec.
@@ -162,6 +164,6 @@ If we've missed an ingredient you'd like to see in common-beer-data, you can for
 
 ## License
 
-Copyright © 2020-2022 - [Wall Brew Co](https://wallbrew.com/)
+Copyright © [Wall Brew Co](https://wallbrew.com/)
 
 This software is provided for free, public use as outlined in the [MIT License](https://github.com/Wall-Brew-Co/common-beer-format/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository follows the guidelines and standards of the [Wall Brew Open Sour
 
 ## Domain Experience
 
-This documentation and library assumes a moderately advanced level of familiarity with homebrewing, specifically the brewing of beer.
+This documentation and library assumes a moderately advanced level of familiarity with homebrewing- specifically the brewing of beer.
 If you are unfamiliar with the brewing process, we highly recommend setting this documentation aside and gathering the essential experience and knowledge first.
 The following resources are great places to begin:
 
@@ -31,6 +31,13 @@ To use it, add the following as a dependency in your project.clj file:
 
 The next time you build your application, [Leiningen](https://leiningen.org/) or [deps.edn](https://clojure.org/guides/deps_and_cli) should pull it automatically.
 Alternatively, you may clone or fork the repository to work with it directly.
+
+## Documentation
+
+common-beer-format's public documentation is available on [cljdoc.](https://cljdoc.org/d/com.wallbrew/common-beer-format/CURRENT)
+Please note that cljdoc does not currently include clojure specs in auto-generated namespace documentation.
+Documentation of the specs contained by this library may be found in the `Specs` article.
+The original markdown copies of this documentation are located in the `doc` folder of this repository.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ The library endeavors to support the data specification as a [clojure spec](http
 
 This repository follows the guidelines and standards of the [Wall Brew Open Source Policy.](https://github.com/Wall-Brew-Co/open-source "Our open source guidelines")
 
+## Domain Experience
+
+This documentation and library assumes a moderately advanced level of familiarity with homebrewing, specifically the brewing of beer.
+If you are unfamiliar with the brewing process, we highly recommend setting this documentation aside and gathering the essential experience and knowledge first.
+The following resources are great places to begin:
+
+- *The Complete Joy of Home Brewing* - Charlie Papazian
+- *How to Brew* - John J. Palmer
+- [The American Homebrewers Association](https://www.homebrewersassociation.org/)
+- A friend, relative, or neighbor with homebrewing experience
+- A local brewery or local homebrewing supply store
+
 ## Installation
 
 A deployed copy of the most recent version of [common-beer-format can be found on clojars.](https://clojars.org/com.wallbrew/common-beer-format)
@@ -46,77 +58,77 @@ Once the file is read and parsed, the code above will return something like this
 ```clj
   {:fermentables
    [{:fermentable
-     {:amount 2.27
-      :yield 78.0
-      :supplier "Fussybrewer Malting"
-      :color 3.0
-      :name "Pale Malt (2 row) UK"
-      :moisture 4.0
-      :type "Grain"
-      :notes "All purpose base malt for English styles"
-      :protein 10.2
-      :origin "United Kingdom"
+     {:amount           2.27
+      :yield            78.0
+      :supplier         "Fussybrewer Malting"
+      :color            3.0
+      :name             "Pale Malt (2 row) UK"
+      :moisture         4.0
+      :type             "Grain"
+      :notes            "All purpose base malt for English styles"
+      :protein          10.2
+      :origin           "United Kingdom"
       :coarse-fine-diff 1.5
-      :version 1
-      :max-in-batch 100.0
-      :diastatic-power 45.0}}
+      :version          1
+      :max-in-batch     100.0
+      :diastatic-power  45.0}}
     {:fermentable
-     {:amount 0.91
-      :yield 70.0
-      :supplier "Fussybrewer Malting"
-      :color 2.0
-      :name "Barley, Flaked"
-      :moisture 9.0
-      :type "Grain"
-      :notes "Adds body to porters and stouts, must be mashed"
-      :protein 13.2
-      :origin "United Kingdom"
+     {:amount           0.91
+      :yield            70.0
+      :supplier         "Fussybrewer Malting"
+      :color            2.0
+      :name             "Barley, Flaked"
+      :moisture         9.0
+      :type             "Grain"
+      :notes            "Adds body to porters and stouts, must be mashed"
+      :protein          13.2
+      :origin           "United Kingdom"
       :coarse-fine-diff 1.5
-      :version 1
-      :max-in-batch 20.0
-      :recommend-mash true
-      :diastatic-power 0.0}}
+      :version          1
+      :max-in-batch     20.0
+      :recommend-mash   true
+      :diastatic-power  0.0}}
     {:fermentable
-     {:amount 0.45
-      :yield 78.0
-      :supplier "Fussybrewer Malting"
-      :color 500.0
-      :name "Black Barley"
-      :moisture 5.0
-      :type "Grain"
-      :notes "Unmalted roasted barley for stouts, porters"
+     {:amount           0.45
+      :yield            78.0
+      :supplier         "Fussybrewer Malting"
+      :color            500.0
+      :name             "Black Barley"
+      :moisture         5.0
+      :type             "Grain"
+      :notes            "Unmalted roasted barley for stouts, porters"
       :coarse-fine-diff 1.5
-      :diastatic-power 0.0
-      :protein 13.2
-      :max-in-batch 10.0}}]}
+      :diastatic-power  0.0
+      :protein          13.2
+      :max-in-batch     10.0}}]}
 ```
 
 This library takes data structured to the [BeerXML](http://www.beerxml.com/beerxml.htm) specification and provides a layer of conformance and coercion.
 
 Specs for the following data types have been provided, as well as several wrappers for container objects:
 
-* [Equipment](/src/common_beer_format/equipment.cljc)
-* [Fermentables](/src/common_beer_format/fermentables.cljc)
-* [Hops](/src/common_beer_format/hops.cljc)
-* [Mash](/src/common_beer_format/mash.cljc)
-* [Miscs](/src/common_beer_format/miscs.cljc)
-* [Recipes](/src/common_beer_format/recipes.cljc)
-* [Styles](/src/common_beer_format/styles.cljc)
-* [Waters](/src/common_beer_format/waters.cljc)
-* [Yeasts](/src/common_beer_format/yeasts.cljc)
+- [Equipment](/src/common_beer_format/equipment.cljc)
+- [Fermentables](/src/common_beer_format/fermentables.cljc)
+- [Hops](/src/common_beer_format/hops.cljc)
+- [Mash](/src/common_beer_format/mash.cljc)
+- [Miscs](/src/common_beer_format/miscs.cljc)
+- [Recipes](/src/common_beer_format/recipes.cljc)
+- [Styles](/src/common_beer_format/styles.cljc)
+- [Waters](/src/common_beer_format/waters.cljc)
+- [Yeasts](/src/common_beer_format/yeasts.cljc)
 
 ### Core Data Functions
 
 In the core namespace, several utility functions have been provided to allow users of common-beer-format to inherit the utilities in `spec-tools`.
-That ssers may use any function from `spec-tools` or `clojure.spec`, with the specs in this library.
+That users may use any function from `spec-tools` or `clojure.spec`, with the specs in this library.
 
 Surfaced functions include:
 
-* `conform`
-* `coerce`
-* `explain`
-* `explain-data`
-* `spec-description`
+- `conform`
+- `coerce`
+- `explain`
+- `explain-data`
+- `spec-description`
 
 ## Additional Notes
 
@@ -133,20 +145,20 @@ To cleanly interop with Clojure Spec, this required the construction of spec wra
 ;; as well as
 
 {:fermentable
-  {:amount 2.27
-   :yield 78.0
-   :supplier "Fussybrewer Malting"
-   :color 3.0
-   :name "Pale Malt (2 row) UK"
-   :moisture 4.0
-   :type "Grain"
-   :notes "All purpose base malt for English styles"
-   :protein 10.2
-   :origin "United Kingdom"
+  {:amount           2.27
+   :yield            78.0
+   :supplier         "Fussybrewer Malting"
+   :color            3.0
+   :name             "Pale Malt (2 row) UK"
+   :moisture         4.0
+   :type             "Grain"
+   :notes            "All purpose base malt for English styles"
+   :protein          10.2
+   :origin           "United Kingdom"
    :coarse-fine-diff 1.5
-   :version 1
-   :max-in-batch 100.0
-   :diastatic-power 45.0}}
+   :version          1
+   :max-in-batch     100.0
+   :diastatic-power  45.0}}
 ```
 
 Therefore, specs named like `::fermentable` and `::fermentables` are used to describe the innermost values- meaning a key-value pair of the data describing a fermentable ingredient or a list of fermentable records.

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -1,0 +1,199 @@
+(ns common-beer-format.spec-export
+  "Exports the specs in common-beer-format to markdown files.
+
+   cljdoc will use these markdown files to generate the documentation for the common-beer-format library.
+   Otherwise, the specs are not easily accessible to the end user.
+
+   This namespace is not intended for public use."
+  {:no-doc true}
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [common-beer-format.core :as cbf]
+            [common-beer-format.equipment :as equipment]
+            [common-beer-format.impl :as impl]))
+
+(defn ->capital-sting
+  "Convert a string sequence to a single string with all words capitalized."
+  [string-sequence]
+  (str/join " " (map str/capitalize string-sequence) ))
+
+(defn spec->human-name
+  "Converts a spec to a human-readable name."
+  [spec]
+  (let [spec-definition (cbf/get-spec spec)]
+    (if (get spec-definition impl/display-name-key)
+      (impl/spec->display-name spec)
+      (-> spec
+          name
+          (str/replace #"-" " ")
+          (str/split #" ")
+          ->capital-sting))))
+
+(defn spec->markdown-link
+  "Converts a spec to a markdown link."
+  [spec]
+  (-> spec
+      spec->human-name
+      str/lower-case
+      (str/replace #" " "-")))
+
+(defn coerce-example-value
+  "Coerces an example value to the spec type."
+  [spec]
+  (let [spec-definition (cbf/get-spec spec)
+        example-value   (:json-schema/example spec-definition)
+        clojure-value   (cbf/coerce spec example-value)]
+    (if (string? clojure-value)
+      (str "\"" clojure-value "\"")
+      clojure-value)))
+
+(defn leaf-spec->markdown
+  "Generates a markdown description of a leaf spec.
+
+   This function generates the appropriate header so the map and sequence specs can link to it."
+  [spec]
+  (let [spec-definition  (cbf/get-spec spec)
+        display-name     (spec->human-name spec)
+        spec-type        (-> spec-definition :type spec->human-name)
+        example-value    (coerce-example-value spec)
+        spec-description (:description spec-definition)]
+
+    (if (:leaf? spec-definition)
+      (str/join
+       "\n"
+       [(str "## " display-name)
+        ""
+        spec-description
+        ""
+        (str "- Key Name: `" (-> spec name keyword) "`")
+        (str "- Type: " spec-type)
+        (str "- Example: `" example-value "`")
+        "" ;; Add a newline at the end
+        ""])
+      (throw (ex-info "Spec is not a leaf spec." {:spec spec})))))
+
+(defn key-spec->markdown
+  "Take the spec for required/optional keys and generate markdown for them."
+  [key-spec]
+  (let [human-name    (spec->human-name key-spec)
+        markdown-link (spec->markdown-link key-spec)]
+    (str "- [" human-name "](#" markdown-link ")\n")))
+
+(defn map-spec->markdown
+  "Generates a markdown description of a map spec."
+  [spec]
+  (let [spec-definition       (cbf/get-spec spec)
+        spec-description      (:description spec-definition)
+        display-name          (spec->human-name spec)
+        key->spec-map         (:spec-tools.parse/key->spec spec-definition)
+        required-keys         (vec (:spec-tools.parse/keys-req spec-definition))
+        required-specs        (sort-by name (vals (select-keys key->spec-map required-keys)))
+        optional-keys         (vec (:spec-tools.parse/keys-opt spec-definition))
+        optional-specs        (sort-by name (vals (select-keys key->spec-map optional-keys)))
+        required-key-markdown (apply str (map key-spec->markdown required-specs))
+        optional-key-markdown (apply str (map key-spec->markdown optional-specs))]
+
+    (if (= :map (:type spec-definition))
+      (str/join
+       "\n"
+       [(str "## " display-name)
+        ""
+        spec-description
+        ""
+        "### Required Keys"
+        ""
+        required-key-markdown
+        ""
+        "### Optional Keys"
+        ""
+        optional-key-markdown
+        ""
+        ""])
+      (throw (ex-info "Spec is not a map spec." {:spec spec})))))
+
+(defn wrapper-spec->markdown
+  "Generates a markdown description of a wrapper spec."
+  [spec]
+  (let [spec-definition       (cbf/get-spec spec)
+        spec-description      (:description spec-definition)
+        display-name          (spec->human-name spec)
+        key->spec-map         (:spec-tools.parse/key->spec spec-definition)
+        required-keys         (vec (:spec-tools.parse/keys-req spec-definition))
+        required-specs        (sort-by name (vals (select-keys key->spec-map required-keys)))
+        required-key-markdown (apply str (map key-spec->markdown required-specs))]
+    (if (impl/wrapper-spec? spec)
+      (str/join
+       "\n"
+       [(str "## " display-name)
+        ""
+        spec-description
+        ""
+        "### Wrapped Record"
+        ""
+        required-key-markdown
+        ""
+        ""])
+      (throw (ex-info "Spec is not a wrapper spec." {:spec spec})))))
+
+(defn sequence-spec->markdown
+    "Generates a markdown description of a sequence spec."
+    [spec]
+    (let [spec-definition       (cbf/get-spec spec)
+          spec-description      (:description spec-definition)
+          display-name          (spec->human-name spec)
+          sequence-spec         (-> spec-definition :spec-tools.parse/item :spec)
+          required-key-markdown (key-spec->markdown sequence-spec)]
+      (if (= :vector (:type spec-definition))
+        (str/join
+         "\n"
+         [(str "## " display-name)
+          ""
+          spec-description
+          ""
+          "### Collection Type"
+          ""
+          required-key-markdown
+          ""
+          ""])
+        (throw (ex-info "Spec is not a sequence spec." {:spec spec})))))
+
+(defn map-spec->leaf-spec-markdown
+  "Generates a markdown description of a map spec that contains leaf specs."
+  [spec]
+  (let [spec-definition (cbf/get-spec spec)
+        key->spec-map   (:spec-tools.parse/key->spec spec-definition)
+        leaf-specs      (sort-by name (vals key->spec-map))
+        leaf-markdown   (apply str (map leaf-spec->markdown leaf-specs))]
+    (if (every? :leaf? (map cbf/get-spec leaf-specs))
+      (str/join
+       "\n"
+       [leaf-markdown
+        ""
+        ""])
+      (throw (ex-info "Spec is not a map spec." {:spec spec})))))
+
+(defn deformat
+  "Remove extra newlines and formatting issues from a string."
+  [^String s]
+  (-> s
+      (str/replace #"\n\n\n\n" "\n")
+      (str/replace #"\n\n\n" "\n\n")))
+
+
+(defn render-equipment-file!
+  "Render the equipment specs to a markdown file."
+  []
+  (io/make-parents "doc/specs/equipment.md")
+  (spit "doc/specs/equipment.md"
+        (deformat
+          (str "# Equipment Records\n\n"
+               (wrapper-spec->markdown ::equipment/equipments-wrapper)
+               (sequence-spec->markdown ::equipment/equipments)
+               (wrapper-spec->markdown ::equipment/equipment-wrapper)
+               (map-spec->markdown ::equipment/equipment)
+               (map-spec->leaf-spec-markdown ::equipment/equipment)))))
+
+(defn render-specs!
+  "Render all the specs to markdown files."
+  []
+  (render-equipment-file!))

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -39,6 +39,7 @@
           (str/split #" ")
           ->capital-sting))))
 
+
 (defn beer-xml-units->markdown
   "Converts a BeerXML unit to a markdown string."
   [units]
@@ -86,19 +87,19 @@
         beer-xml-units   (get spec-definition impl/beer-xml-units-key)]
     (if (:leaf? spec-definition)
       (impl/multiline
-       (str "## " display-name)
-       ""
-       spec-description
-       ""
-       (when beer-xml-type
-         (str "- BeerXML Type: `" beer-xml-type "`"))
-       (when beer-xml-units
-         (beer-xml-units->markdown beer-xml-units))
-       (str "- Clojure Key Name: `" (-> spec name keyword) "`")
-       (str "- Clojure Type: " spec-type)
-       (str "- Example: `" example-value "`")
-       "" ; Add a newline at the end
-       "")
+        (str "## " display-name)
+        ""
+        spec-description
+        ""
+        (when beer-xml-type
+          (str "- BeerXML Type: `" beer-xml-type "`"))
+        (when beer-xml-units
+          (beer-xml-units->markdown beer-xml-units))
+        (str "- Clojure Key Name: `" (-> spec name keyword) "`")
+        (str "- Clojure Type: " spec-type)
+        (str "- Example: `" example-value "`")
+        "" ; Add a newline at the end
+        "")
       (throw (ex-info "Spec is not a leaf spec." {:spec spec})))))
 
 
@@ -127,19 +128,19 @@
 
     (if (= :map (:type spec-definition))
       (impl/multiline
-       (str "## " display-name)
-       ""
-       spec-description
-       ""
-       "### Required Keys"
-       ""
-       required-key-markdown
-       ""
-       "### Optional Keys"
-       ""
-       optional-key-markdown
-       ""
-       "")
+        (str "## " display-name)
+        ""
+        spec-description
+        ""
+        "### Required Keys"
+        ""
+        required-key-markdown
+        ""
+        "### Optional Keys"
+        ""
+        optional-key-markdown
+        ""
+        "")
       (throw (ex-info "Spec is not a map spec." {:spec spec})))))
 
 
@@ -157,18 +158,18 @@
         beer-xml-type         (get spec-definition impl/beer-xml-type-key)]
     (if (impl/wrapper-spec? spec)
       (impl/multiline
-       (str "## " display-name)
-       ""
-       spec-description
-       ""
-       (when beer-xml-type
-         (str "- BeerXML Type: `" beer-xml-type "`"))
-       ""
-       "### Wrapped Record"
-       ""
-       required-key-markdown
-       ""
-       "")
+        (str "## " display-name)
+        ""
+        spec-description
+        ""
+        (when beer-xml-type
+          (str "- BeerXML Type: `" beer-xml-type "`"))
+        ""
+        "### Wrapped Record"
+        ""
+        required-key-markdown
+        ""
+        "")
       (throw (ex-info "Spec is not a wrapper spec." {:spec spec})))))
 
 
@@ -183,15 +184,15 @@
         required-key-markdown (key-spec->markdown sequence-spec)]
     (if (= :vector (:type spec-definition))
       (impl/multiline
-       (str "## " display-name)
-       ""
-       spec-description
-       ""
-       "### Collection Type"
-       ""
-       required-key-markdown
-       ""
-       "")
+        (str "## " display-name)
+        ""
+        spec-description
+        ""
+        "### Collection Type"
+        ""
+        required-key-markdown
+        ""
+        "")
       (throw (ex-info "Spec is not a sequence spec." {:spec spec})))))
 
 
@@ -231,6 +232,7 @@
                (map-spec->markdown ::equipment/equipment)
                (map-spec->leaf-spec-markdown ::equipment/equipment)))))
 
+
 (defn render-fermentables-file!
   "Render the fermentable specs to a markdown file."
   []
@@ -245,6 +247,7 @@
                (map-spec->markdown ::fermentables/fermentable)
                (map-spec->leaf-spec-markdown ::fermentables/fermentable)))))
 
+
 (defn render-hop-file!
   "Render the hop specs to a markdown file."
   []
@@ -258,6 +261,7 @@
                (wrapper-spec->markdown ::hops/hop-wrapper)
                (map-spec->markdown ::hops/hop)
                (map-spec->leaf-spec-markdown ::hops/hop)))))
+
 
 (defn render-mash-file!
   "Render the mash specs to a markdown file."
@@ -278,6 +282,7 @@
                (map-spec->markdown ::mash/mash-step)
                (map-spec->leaf-spec-markdown ::mash/mash-step)))))
 
+
 (defn render-miscs-file!
   "Render the misc specs to a markdown file."
   []
@@ -291,6 +296,7 @@
                (wrapper-spec->markdown ::miscs/misc-wrapper)
                (map-spec->markdown ::miscs/misc)
                (map-spec->leaf-spec-markdown ::miscs/misc)))))
+
 
 (defn render-recipes-file!
   "Render the recipe specs to a markdown file."
@@ -306,6 +312,7 @@
                (map-spec->markdown ::recipes/recipe)
                (map-spec->leaf-spec-markdown ::recipes/recipe)))))
 
+
 (defn render-styles-file!
   "Render the style specs to a markdown file."
   []
@@ -320,6 +327,7 @@
                (map-spec->markdown ::styles/style)
                (map-spec->leaf-spec-markdown ::styles/style)))))
 
+
 (defn render-waters-file!
   "Render the water specs to a markdown file."
   []
@@ -333,6 +341,7 @@
                (wrapper-spec->markdown ::waters/water-wrapper)
                (map-spec->markdown ::waters/water)
                (map-spec->leaf-spec-markdown ::waters/water)))))
+
 
 (defn render-yeasts-file!
   "Render the yeast specs to a markdown file."
@@ -350,6 +359,8 @@
 
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+
+
 (defn render-specs!
   "Render all the specs to markdown files."
   []

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -39,6 +39,17 @@
           (str/split #" ")
           ->capital-sting))))
 
+(defn beer-xml-units->markdown
+  "Converts a BeerXML unit to a markdown string."
+  [units]
+  (let [units-seq (cond
+                    (string? units) [units]
+                    (sequential? units) units
+                    :else (throw (ex-info "Units must be a string or a sequence." {:units units})))]
+    (if (= 1 (count units-seq))
+      (str "- BeerXML Unit: " (first units-seq))
+      (str "- BeerXML Units: " (str/join ", " units-seq)))))
+
 
 (defn spec->markdown-link
   "Converts a spec to a markdown link."
@@ -82,7 +93,7 @@
        (when beer-xml-type
          (str "- BeerXML Type: `" beer-xml-type "`"))
        (when beer-xml-units
-         (str "- BeerXML Units: `" beer-xml-units "`"))
+         (beer-xml-units->markdown beer-xml-units))
        (str "- Clojure Key Name: `" (-> spec name keyword) "`")
        (str "- Clojure Type: " spec-type)
        (str "- Example: `" example-value "`")
@@ -151,7 +162,7 @@
        spec-description
        ""
        (when beer-xml-type
-         (str "BeerXML Type: `" beer-xml-type "`"))
+         (str "- BeerXML Type: `" beer-xml-type "`"))
        ""
        "### Wrapped Record"
        ""
@@ -256,6 +267,8 @@
   (spit "doc/specs/mash.md"
         (deformat
           (str "# Mash Records\n\n"
+               (wrapper-spec->markdown ::mash/mashs-wrapper)
+               (sequence-spec->markdown ::mash/mashs)
                (wrapper-spec->markdown ::mash/mash-wrapper)
                (map-spec->markdown ::mash/mash)
                (map-spec->leaf-spec-markdown ::mash/mash)

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -4,7 +4,7 @@
    cljdoc will use these markdown files to generate the documentation for the common-beer-format library.
    Otherwise, the specs are not easily accessible to the end user.
 
-   This namespace is not intended for public use."
+   This namespace is not intended for public use and is not bundled into the source code."
   {:no-doc true}
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
@@ -13,7 +13,12 @@
             [common-beer-format.fermentables :as fermentables]
             [common-beer-format.hops :as hops]
             [common-beer-format.impl :as impl]
-            [common-beer-format.mash :as mash]))
+            [common-beer-format.mash :as mash]
+            [common-beer-format.miscs :as miscs]
+            [common-beer-format.recipes :as recipes]
+            [common-beer-format.styles :as styles]
+            [common-beer-format.waters :as waters]
+            [common-beer-format.yeasts :as yeasts]))
 
 
 (defn ->capital-sting
@@ -250,6 +255,77 @@
                (map-spec->markdown ::mash/mash-step)
                (map-spec->leaf-spec-markdown ::mash/mash-step)))))
 
+(defn render-miscs-file!
+  "Render the misc specs to a markdown file."
+  []
+  (println "Rendering misc file")
+  (io/make-parents "doc/specs/miscs.md")
+  (spit "doc/specs/miscs.md"
+        (deformat
+          (str "# Misc Records\n\n"
+               (wrapper-spec->markdown ::miscs/miscs-wrapper)
+               (sequence-spec->markdown ::miscs/miscs)
+               (wrapper-spec->markdown ::miscs/misc-wrapper)
+               (map-spec->markdown ::miscs/misc)
+               (map-spec->leaf-spec-markdown ::miscs/misc)))))
+
+(defn render-recipes-file!
+  "Render the recipe specs to a markdown file."
+  []
+  (println "Rendering recipe file")
+  (io/make-parents "doc/specs/recipes.md")
+  (spit "doc/specs/recipes.md"
+        (deformat
+          (str "# Recipe Records\n\n"
+               (wrapper-spec->markdown ::recipes/recipes-wrapper)
+               (sequence-spec->markdown ::recipes/recipes)
+               (wrapper-spec->markdown ::recipes/recipe-wrapper)
+               (map-spec->markdown ::recipes/recipe)
+               (map-spec->leaf-spec-markdown ::recipes/recipe)))))
+
+(defn render-styles-file!
+  "Render the style specs to a markdown file."
+  []
+  (println "Rendering style file")
+  (io/make-parents "doc/specs/styles.md")
+  (spit "doc/specs/styles.md"
+        (deformat
+          (str "# Style Records\n\n"
+               (wrapper-spec->markdown ::styles/styles-wrapper)
+               (sequence-spec->markdown ::styles/styles)
+               (wrapper-spec->markdown ::styles/style-wrapper)
+               (map-spec->markdown ::styles/style)
+               (map-spec->leaf-spec-markdown ::styles/style)))))
+
+(defn render-waters-file!
+  "Render the water specs to a markdown file."
+  []
+  (println "Rendering water file")
+  (io/make-parents "doc/specs/water.md")
+  (spit "doc/specs/water.md"
+        (deformat
+          (str "# Water Records\n\n"
+               (wrapper-spec->markdown ::waters/waters-wrapper)
+               (sequence-spec->markdown ::waters/waters)
+               (wrapper-spec->markdown ::waters/water-wrapper)
+               (map-spec->markdown ::waters/water)
+               (map-spec->leaf-spec-markdown ::waters/water)))))
+
+(defn render-yeasts-file!
+  "Render the yeast specs to a markdown file."
+  []
+  (println "Rendering yeast file")
+  (io/make-parents "doc/specs/yeast.md")
+  (spit "doc/specs/yeast.md"
+        (deformat
+          (str "# Yeast Records\n\n"
+               (wrapper-spec->markdown ::yeasts/yeasts-wrapper)
+               (sequence-spec->markdown ::yeasts/yeasts)
+               (wrapper-spec->markdown ::yeasts/yeast-wrapper)
+               (map-spec->markdown ::yeasts/yeast)
+               (map-spec->leaf-spec-markdown ::yeasts/yeast)))))
+
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn render-specs!
   "Render all the specs to markdown files."
@@ -257,4 +333,9 @@
   (render-equipment-file!)
   (render-fermentables-file!)
   (render-hop-file!)
-  (render-mash-file!))
+  (render-mash-file!)
+  (render-miscs-file!)
+  (render-recipes-file!)
+  (render-styles-file!)
+  (render-waters-file!)
+  (render-yeasts-file!))

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -12,10 +12,12 @@
             [common-beer-format.equipment :as equipment]
             [common-beer-format.impl :as impl]))
 
+
 (defn ->capital-sting
   "Convert a string sequence to a single string with all words capitalized."
   [string-sequence]
-  (str/join " " (map str/capitalize string-sequence) ))
+  (str/join " " (map str/capitalize string-sequence)))
+
 
 (defn spec->human-name
   "Converts a spec to a human-readable name."
@@ -29,6 +31,7 @@
           (str/split #" ")
           ->capital-sting))))
 
+
 (defn spec->markdown-link
   "Converts a spec to a markdown link."
   [spec]
@@ -36,6 +39,7 @@
       spec->human-name
       str/lower-case
       (str/replace #" " "-")))
+
 
 (defn coerce-example-value
   "Coerces an example value to the spec type."
@@ -46,6 +50,7 @@
     (if (string? clojure-value)
       (str "\"" clojure-value "\"")
       clojure-value)))
+
 
 (defn leaf-spec->markdown
   "Generates a markdown description of a leaf spec.
@@ -60,17 +65,18 @@
 
     (if (:leaf? spec-definition)
       (str/join
-       "\n"
-       [(str "## " display-name)
-        ""
-        spec-description
-        ""
-        (str "- Key Name: `" (-> spec name keyword) "`")
-        (str "- Type: " spec-type)
-        (str "- Example: `" example-value "`")
-        "" ;; Add a newline at the end
-        ""])
+        "\n"
+        [(str "## " display-name)
+         ""
+         spec-description
+         ""
+         (str "- Key Name: `" (-> spec name keyword) "`")
+         (str "- Type: " spec-type)
+         (str "- Example: `" example-value "`")
+         "" ; Add a newline at the end
+         ""])
       (throw (ex-info "Spec is not a leaf spec." {:spec spec})))))
+
 
 (defn key-spec->markdown
   "Take the spec for required/optional keys and generate markdown for them."
@@ -78,6 +84,7 @@
   (let [human-name    (spec->human-name key-spec)
         markdown-link (spec->markdown-link key-spec)]
     (str "- [" human-name "](#" markdown-link ")\n")))
+
 
 (defn map-spec->markdown
   "Generates a markdown description of a map spec."
@@ -95,21 +102,22 @@
 
     (if (= :map (:type spec-definition))
       (str/join
-       "\n"
-       [(str "## " display-name)
-        ""
-        spec-description
-        ""
-        "### Required Keys"
-        ""
-        required-key-markdown
-        ""
-        "### Optional Keys"
-        ""
-        optional-key-markdown
-        ""
-        ""])
+        "\n"
+        [(str "## " display-name)
+         ""
+         spec-description
+         ""
+         "### Required Keys"
+         ""
+         required-key-markdown
+         ""
+         "### Optional Keys"
+         ""
+         optional-key-markdown
+         ""
+         ""])
       (throw (ex-info "Spec is not a map spec." {:spec spec})))))
+
 
 (defn wrapper-spec->markdown
   "Generates a markdown description of a wrapper spec."
@@ -123,39 +131,41 @@
         required-key-markdown (apply str (map key-spec->markdown required-specs))]
     (if (impl/wrapper-spec? spec)
       (str/join
-       "\n"
-       [(str "## " display-name)
-        ""
-        spec-description
-        ""
-        "### Wrapped Record"
-        ""
-        required-key-markdown
-        ""
-        ""])
+        "\n"
+        [(str "## " display-name)
+         ""
+         spec-description
+         ""
+         "### Wrapped Record"
+         ""
+         required-key-markdown
+         ""
+         ""])
       (throw (ex-info "Spec is not a wrapper spec." {:spec spec})))))
 
+
 (defn sequence-spec->markdown
-    "Generates a markdown description of a sequence spec."
-    [spec]
-    (let [spec-definition       (cbf/get-spec spec)
-          spec-description      (:description spec-definition)
-          display-name          (spec->human-name spec)
-          sequence-spec         (-> spec-definition :spec-tools.parse/item :spec)
-          required-key-markdown (key-spec->markdown sequence-spec)]
-      (if (= :vector (:type spec-definition))
-        (str/join
-         "\n"
-         [(str "## " display-name)
-          ""
-          spec-description
-          ""
-          "### Collection Type"
-          ""
-          required-key-markdown
-          ""
-          ""])
-        (throw (ex-info "Spec is not a sequence spec." {:spec spec})))))
+  "Generates a markdown description of a sequence spec."
+  [spec]
+  (let [spec-definition       (cbf/get-spec spec)
+        spec-description      (:description spec-definition)
+        display-name          (spec->human-name spec)
+        sequence-spec         (-> spec-definition :spec-tools.parse/item :spec)
+        required-key-markdown (key-spec->markdown sequence-spec)]
+    (if (= :vector (:type spec-definition))
+      (str/join
+        "\n"
+        [(str "## " display-name)
+         ""
+         spec-description
+         ""
+         "### Collection Type"
+         ""
+         required-key-markdown
+         ""
+         ""])
+      (throw (ex-info "Spec is not a sequence spec." {:spec spec})))))
+
 
 (defn map-spec->leaf-spec-markdown
   "Generates a markdown description of a map spec that contains leaf specs."
@@ -166,11 +176,12 @@
         leaf-markdown   (apply str (map leaf-spec->markdown leaf-specs))]
     (if (every? :leaf? (map cbf/get-spec leaf-specs))
       (str/join
-       "\n"
-       [leaf-markdown
-        ""
-        ""])
+        "\n"
+        [leaf-markdown
+         ""
+         ""])
       (throw (ex-info "Spec is not a map spec." {:spec spec})))))
+
 
 (defn deformat
   "Remove extra newlines and formatting issues from a string."
@@ -192,6 +203,7 @@
                (wrapper-spec->markdown ::equipment/equipment-wrapper)
                (map-spec->markdown ::equipment/equipment)
                (map-spec->leaf-spec-markdown ::equipment/equipment)))))
+
 
 (defn render-specs!
   "Render all the specs to markdown files."

--- a/dev/common_beer_format/spec_export.clj
+++ b/dev/common_beer_format/spec_export.clj
@@ -70,15 +70,21 @@
         display-name     (spec->human-name spec)
         spec-type        (-> spec-definition :type spec->human-name)
         example-value    (coerce-example-value spec)
-        spec-description (:description spec-definition)]
+        spec-description (:description spec-definition)
+        beer-xml-type    (get spec-definition impl/beer-xml-type-key)
+        beer-xml-units   (get spec-definition impl/beer-xml-units-key)]
     (if (:leaf? spec-definition)
       (impl/multiline
        (str "## " display-name)
        ""
        spec-description
        ""
-       (str "- Key Name: `" (-> spec name keyword) "`")
-       (str "- Type: " spec-type)
+       (when beer-xml-type
+         (str "- BeerXML Type: `" beer-xml-type "`"))
+       (when beer-xml-units
+         (str "- BeerXML Units: `" beer-xml-units "`"))
+       (str "- Clojure Key Name: `" (-> spec name keyword) "`")
+       (str "- Clojure Type: " spec-type)
        (str "- Example: `" example-value "`")
        "" ; Add a newline at the end
        "")
@@ -136,12 +142,16 @@
         key->spec-map         (:spec-tools.parse/key->spec spec-definition)
         required-keys         (vec (:spec-tools.parse/keys-req spec-definition))
         required-specs        (sort-by name (vals (select-keys key->spec-map required-keys)))
-        required-key-markdown (apply str (map key-spec->markdown required-specs))]
+        required-key-markdown (apply str (map key-spec->markdown required-specs))
+        beer-xml-type         (get spec-definition impl/beer-xml-type-key)]
     (if (impl/wrapper-spec? spec)
       (impl/multiline
        (str "## " display-name)
        ""
        spec-description
+       ""
+       (when beer-xml-type
+         (str "BeerXML Type: `" beer-xml-type "`"))
        ""
        "### Wrapped Record"
        ""

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -5,9 +5,15 @@
                     ["Code of Conduct" {:file "CODE_OF_CONDUCT.md"}]
                     ["Security Policy" {:file "SECURITY.md"}]]
                    ["Functionality" {}
-                    ["Specs" {}
+                    ["Specs" {:file "doc/specs.md"}
                      ["Equipment" {:file "doc/specs/equipment.md"}]
                      ["Fermentables" {:file "doc/specs/fermentables.md"}]
-                     ["Hops" {:file "doc/specs/hops.md"}]]]
+                     ["Hops" {:file "doc/specs/hops.md"}]
+                     ["Mash" {:file "doc/specs/mash.md"}]
+                     ["Miscs" {:file "doc/specs/miscs.md"}]
+                     ["Recipes" {:file "doc/specs/recipes.md"}]
+                     ["Styles" {:file "doc/specs/styles.md"}]
+                     ["Water" {:file "doc/specs/water.md"}]
+                     ["Yeast" {:file "doc/specs/yeast.md"}]]]
                    ["Adopted Patterns" {}
                     ["Symbolic Keywords" {:file "doc/patterns/symbolic_keywords.md"}]]]}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,11 @@
+{:cljdoc.doc/tree [["Readme" {:file "README.md"}]
+                   ["Changelog" {:file "CHANGELOG.md"}]
+                   ["Community" {}
+                    ["Contributing" {:file "CONTRIBUTING.md"}]
+                    ["Code of Conduct" {:file "CODE_OF_CONDUCT.md"}]
+                    ["Security Policy" {:file "SECURITY.md"}]]
+                   ["Functionality" {}
+                    ["Specs" {}
+                     ["Equipment" {:file "doc/specs/equipment.md"}]]]
+                   ["Adopted Patterns" {}
+                    ["Symbolic Keywords" {:file "doc/patterns/symbolic_keywords.md"}]]]}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -6,6 +6,8 @@
                     ["Security Policy" {:file "SECURITY.md"}]]
                    ["Functionality" {}
                     ["Specs" {}
-                     ["Equipment" {:file "doc/specs/equipment.md"}]]]
+                     ["Equipment" {:file "doc/specs/equipment.md"}]
+                     ["Fermentables" {:file "doc/specs/fermentables.md"}]
+                     ["Hops" {:file "doc/specs/hops.md"}]]]
                    ["Adopted Patterns" {}
                     ["Symbolic Keywords" {:file "doc/patterns/symbolic_keywords.md"}]]]}

--- a/doc/patterns/symbolic_keywords.md
+++ b/doc/patterns/symbolic_keywords.md
@@ -1,0 +1,51 @@
+# Symbolic Keywords
+
+In many clojure libraries, the behavior of complex functions may be controlled by a map.
+For example:
+
+```clojure
+(:require [brewtility.units :as units])
+(units/display :volume 1.5 :liter) ;; => "1.5 l"
+(units/display :volume 1.5 :liter {:suffix :full}) ;; => "1.5 liter"
+```
+
+This allows us to easily extend the definition of a single function to fulfill multiple complex needs; however, option maps come with considerable drawbacks.
+When a map is keyed with keywords, it is easy to introduce subtle, hard-to-detect errors.
+Since most of these functions select default values for keys not present, typos can lead to meaningful differences in behavior.
+For example:
+
+```clojure
+(:require [brewtility.units :as units])
+(units/display :volume 1.5 :liter) ;; => "1.5 l"
+
+;; Not the missing "f" in the key :sufix
+(units/display :volume 1.5 :liter {:sufix :full}) ;; => "1.5 l"
+```
+
+Because keywords aren't picked up by the auto-complete features of most editors, they're vulnerable to all classes of transpositional errors.
+Further, the options themselves are unable to carry metadata and documentation with them, making them little more than magic values.
+
+For this reason, it is helpful for libraries to include symbols which point to the "magic" keywords used in option maps.
+This has several benefits:
+
+- Misspelled or incorrect option keys are compile-time errors, instead of runtime bugs
+- Symbols can carry metadata like documentation, deprecation notices, and point to alternative options
+- Context-aware editors can auto-complete options
+
+Here's can example:
+
+```clojure
+(:require [brewtility.units :as units]
+          [brewtility.units.options :as options])
+
+(units/display options/volume 1.5 options/liter) ;; => "1.5 l"
+(units/display options/volume 1.5 options/liter {options/suffix options/full}) ;; => "1.5 liter"
+```
+
+Most option maps in `brewtility` support symbolic keywords.
+These keywords are available in the namespaces ending in `.options`.
+These files live as close to the code relying on them as possible;
+for example, the options for all unit conversion operations (e.g. `brewtility.units`, `brewtility.units.time`, `brewtility.units.color`, etc.) are available in `brewtility.units.options`.
+
+Further, the option keywords are preferred for library development.
+A single source of truth for the name of a common option, such as `precision`, limits the possibility of incorrectly retrieving the values used by that option.

--- a/doc/specs.md
+++ b/doc/specs.md
@@ -226,6 +226,10 @@ The color of a fermentable is described in degrees Lovibond with one exception.
 Fermentables of the "Liquid Extract" type are measured with the Standard Reference Model.
 Styles and recipes measure their color with the Standard Reference Model.
 
+###### Specific Heat
+
+Specific heat is measured in Calories per Gram Degree Celsius.
+
 ### Optional Extensions
 
 BeerXML version 1 has been updated with a single appendix describing optional extensions.

--- a/doc/specs.md
+++ b/doc/specs.md
@@ -1,0 +1,237 @@
+# Common Beer Format Specs
+
+This documentation assumes a moderately advanced level of familiarity with homebrewing, specifically the brewing of beer.
+If you are unfamiliar with the brewing process, we highly recommend setting this documentation aside and gathering the essential experience and knowledge first.
+The following resources are great places to begin:
+
+- *The Complete Joy of Home Brewing* - Charlie Papazian
+- *How to Brew* - John J. Palmer
+- [The American Homebrewers Association](https://www.homebrewersassociation.org/)
+- A friend, relative, or neighbor with homebrewing experience
+- A local brewery or local homebrewing supply store
+
+common-beer-format is a collection of Clojure Specs that describe the BeerXML 1.0 Schema.
+Since it is based on XML, the data shapes and conventions may differ from what Clojure programmers may traditionally expect; however, to maximize interoperability with other brewing programs, common-beer-format maintains as much of the original implementation's choices as possible.
+This document covers how the BeerXML spec has been translated to clojure.
+There is additional documentation containing examples and explanations of the data fields covered by these specs in files named after each central entity: For example, Hops.
+
+## General
+
+BeerXML's implementation expects separate tags for each datum.
+For example:
+
+```xml
+<HOP>
+ <NAME>Cascade</NAME>
+ <USE>Boil</USE>
+ ...
+</HOP>
+```
+
+The specification explicitly states that XML Attributes are **not** to be used.
+For example:
+
+```xml
+<HOP NAME="Cascade" USE="BOIL" ...> </HOP>
+```
+
+In clojure, each entity is represented by a nested map:
+
+```clj
+{:hop
+  {:name "Cascade"
+   :use   "Boil"
+   ...}}
+```
+
+Tools like clj-xml can convert between the clojure map expression and the XML expression of the data directly.
+Alternative implementation choices do exist for this combination of type and attribute mapping (e.g. namespaced keywords, qualified keywords); however, they require additional processing to (de)serialize correctly and are not structurally equivalent to the XML they represent.
+Throughout common-beer-format, the nesting maps in these data shapes are called `wrappers`.
+The specs for these types contain metadata indicating them as such; however, consumers shouldn't need to rely on that fact.
+
+### Tag Names
+
+common-beer-format specs are written for `kebab-cased` maps.
+(De)serialization tools, such as `clj-xml`, are able to automatically format between that casing and the `SCREAMING_SNAKE_CASE` defined in BeerXML.
+
+### Version
+
+All records contain a `:version` key that denotes the version of the BeerXML / common-beer-format standard they represent.
+This version key is independent of the version of any libraries or tools which may process this data.
+As of writing, the only acceptable value for this key is `1`.
+The original BeerXML spec intends to maintain backwards compatibility with any future versions; however this key is intended for handling any instances where that is the exception.
+
+### Non-Standard Fields
+
+The specs contained in this library are open.
+Consumers may add additional keys to any of the maps to store whatever additional information they desire.
+For example an `id` to uniquely represent a specific hop varietal.
+Any fields not defined by this specification may be safely ignored by programs consuming data in this format.
+
+### Data Formats
+
+BeerXML specifies the following data types.
+We've included information about the clojure implementation of each.
+
+#### Record Sets
+
+A **Record Set** is a collection of [Record](#records)s.
+For example, a collection of hops.
+In common-beer-format, these are wrapped maps.
+For example:
+
+```xml
+<HOPS>
+    <HOP>
+        <NAME>Goldings, East Kent</NAME>
+        <VERSION>1</VERSION>
+        <ALPHA>5.0</ALPHA>
+        <AMOUNT>0.0638</AMOUNT>
+        <USE>Boil</USE>
+        <TIME>60.0</TIME>
+        <NOTES>Great all purpose UK hop for ales, stouts, porters</NOTES>
+    </HOP>
+</HOPS>
+```
+
+Becomes:
+
+```clj
+{:hops [{:hop {:name    "Goldings, East Kent"
+               :version 1
+               :alpha   5.0
+               :amount  0.0638
+               :use     "Boil"
+               :time    60.0
+               :notes   "Great all purpose UK hop for ales, stouts, porters"}}]}
+```
+
+#### Records
+
+Records are the core entity types in BeerXML and common-beer-format.
+The following record types are currently supported:
+
+- **Hop**: All varieties and forms of hops.
+  Includes plugs, pellets, and whole cones.
+- **Fermentable**: Any and all ingredients containing substantial fermentable sugar.
+   Includes malt extract, milled grain, candi sugar, honey, and fruit.
+- **Yeast**: All varieties and forms of yeast.
+- **Misc**: Any non-hop, non-yeast ingredient that does not significantly change the gravity of the beer.
+  For example: herbs, water treatment agents, clarifying agents.
+- **Water**: The chemical profile of the water used in mashing and boiling.
+- **Style**: A description of a beer style.
+  The style may come from any source.
+  For example the [Beer Judge Certification Program](https://www.bjcp.org/)
+- **Mash Step**: A single step in a mashing process.
+  This is not intended for use outside of a mash profile.
+- **Mash**: A description of the mashing method used and all mash steps in the process.
+- **Recipe**: A single recipe, largely composed of the other record types.
+- **Equipment**: The equipment used during the mashing and boiling steps.
+
+BeerXML specifically denotes the required and optional fields of each record type.
+common-beer-format specs for records do the same by defining the keys of representative maps as required, unqualified keys and optional, unqualified keys.
+
+Definitions and documentation of these records and their keys are stored individually by Record type.
+
+#### Percentage
+
+An IEEE-754 floating point number used to express a percent out of 100.
+For example, 10.4% will stored and transmitted as `10.4` **NOT** `0.104`.
+The encoding of this field does not contain the `%` character.
+
+#### List / Enumerations
+
+BeerXML specifies a `List` data format, which is also frequently called an `enumeration`.
+All list/enumeration types in BeerXML and common-beer-format are case-sensitive strings.
+
+#### Text
+
+Text is any free-format user provided text.
+For multiline files, line breaks should be preserved and importing programs may choose to truncate text if required.
+Multiline entries may use either Unix-style newlines, or DOS-style carriage return and newline combinations.
+Importing programs **MUST** accept either format.
+
+#### Boolean
+
+The BeerXML spec serializes the boolean type to the literal strings `"TRUE"` and `"FALSE"`.
+common-beer-format deserializes these values to the literal clojure values `true` and `false`.
+Non-boolean representation of "truthiness" and "falsiness", e.g. `nil`, are **NOT** considered valid.
+
+#### Integer / Long
+
+Any integer value with no decimal point, which may include negative numbers.
+common-beer-format will deserialize this type into a `long`.
+
+#### Floating Point
+
+An IEEE-754 floating point number expressed in its simplest form: `1.2`, `0.0004`, etc.
+Importing programs should endeavor to maintain as many significant digits of precession as possible.
+
+### Units of Measure
+
+Data serialized into common-beer-format and BeerXML prescribes the unit of measure for most numeric fields (e.g. `amount`).
+These specifications also describe `display` fields for most measurements (e.g. `display-color-max`).
+The `display` fields are permitted to be stored with any measurement system, but are not intended for use in calculations.
+Importing and exporting programs may use alternative units of measure in their internal processing, but must serialize to and expect to deserialize form the below units.
+
+Clojure unit conversion functions may be found in [brewtility.](https://github.com/Wall-Brew-Co/brewtility "A collection of tools for working with common-beer-format adhering data")
+
+#### Weight
+
+Weight is measured in Kilograms (kg).
+
+#### Volume
+
+Volume is measured in Liters (l).
+In support of the common non-English spelling, most Wall Brew repositories will accept `Litre` as an equivalent name.
+
+#### Temperature
+
+Temperature is measured in degrees Celsius.
+
+#### Time
+
+Time is measured in minutes, unless superseded in a description of a field.
+
+#### Specific Gravity
+
+Specific gravity is measured relative to the weight of a same-sized sample of neutral water.
+For example: `1.030`
+
+#### Pressure
+
+Pressure is measured in Kilopascals (kpa).
+
+##### Implicit Unit Types
+
+BeerXML also includes several fields with implicitly described units of measure that were not formalized into the units standard.
+These units are conventional for home brewers, but may not be described by a matching SI unit.
+When handling data that describes the following measures, these unit systems are used:
+
+###### Alcohol Content
+
+Alcohol content is described in a [percent](#percentage) alcohol by volume.
+
+###### Bitterness
+
+Bitterness is described in [International Bitterness Units.](https://en.wikipedia.org/wiki/International_bitterness_units)
+
+###### Carbonation
+
+Carbonation is described in equivalent volumes of carbon dioxide (CO2).
+
+###### Color
+
+The color of a fermentable is described in degrees Lovibond with one exception.
+Fermentables of the "Liquid Extract" type are measured with the Standard Reference Model.
+Styles and recipes measure their color with the Standard Reference Model.
+
+### Optional Extensions
+
+BeerXML version 1 has been updated with a single appendix describing optional extensions.
+common-beer-format contains specs for these extensions, and they are implemented as optional, unqualified keys in [Records.](#records)
+
+## Additional Reading
+
+- [BeerXML 1.0 Schema](http://www.beerxml.com/beerxml.htm)
+- [Clojure Spec Guide](https://clojure.org/guides/spec)

--- a/doc/specs.md
+++ b/doc/specs.md
@@ -147,6 +147,7 @@ All list/enumeration types in BeerXML and common-beer-format are case-sensitive 
 #### Text
 
 Text is any free-format user provided text.
+In all cases, the empty string, and strings only including whitespace characters, are considered invalid.
 For multiline files, line breaks should be preserved and importing programs may choose to truncate text if required.
 Multiline entries may use either Unix-style newlines, or DOS-style carriage return and newline combinations.
 Importing programs **MUST** accept either format.

--- a/doc/specs/equipment.md
+++ b/doc/specs/equipment.md
@@ -2,9 +2,9 @@
 
 ## Equipments Wrapper
 
-An ::equipment-wrapper record.
+An `::equipment-wrapper` record set.
 
-BeerXML Type: `Record Set`
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -12,7 +12,7 @@ BeerXML Type: `Record Set`
 
 ## Equipments
 
-A vector of valid ::equipment-wrapper records.
+A vector of valid `::equipment-wrapper` records.
 
 ### Collection Type
 
@@ -22,7 +22,7 @@ A vector of valid ::equipment-wrapper records.
 
 An `::equipment` record wrapped in an `:equipment` map.
 
-BeerXML Type: `Record`
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -67,7 +67,7 @@ A record representing the brewing equipment used in brewing.
 A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:batch-size`
 - Clojure Type: Double
 - Example: `5.8`
@@ -77,7 +77,7 @@ A non-negative IEEE-754 floating point number representing the target volume of 
 A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:boil-size`
 - Clojure Type: Double
 - Example: `10.8`
@@ -87,7 +87,7 @@ A non-negative IEEE-754 floating point number representing the pre-boil volume f
 A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Minute`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:boil-time`
 - Clojure Type: Double
 - Example: `15.0`
@@ -180,7 +180,7 @@ A non-empty string denoting a display value for the empty weight of the mash tun
 A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil.
 
 - BeerXML Type: `Percentage`
-- BeerXML Units: `Percent per Hour`
+- BeerXML Unit: Percent per Hour
 - Clojure Key Name: `:evap-rate`
 - Clojure Type: Double
 - Example: `1.2`
@@ -199,7 +199,7 @@ A non-negative IEEE-754 floating point number representing the percentage of lar
 A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:lauter-deadspace`
 - Clojure Type: Double
 - Example: `0.1`
@@ -208,6 +208,7 @@ A non-negative IEEE-754 floating point number representing the volume of wort lo
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -216,6 +217,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -225,7 +227,7 @@ A non-empty string representing any notes about the subject.
 A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:top-up-kettle`
 - Clojure Type: Double
 - Example: `2.1`
@@ -235,7 +237,7 @@ A non-negative IEEE-754 floating point number representing the volume of top-up 
 A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:top-up-water`
 - Clojure Type: Double
 - Example: `2.1`
@@ -245,7 +247,7 @@ A non-negative IEEE-754 floating point number representing the volume of top-up 
 A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:trub-chiller-loss`
 - Clojure Type: Double
 - Example: `0.1`
@@ -255,7 +257,7 @@ A non-negative IEEE-754 floating point number representing the volume of wort lo
 A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Calories per Gram Degree Celsius`
+- BeerXML Unit: Calories per Gram Degree Celsius
 - Clojure Key Name: `:tun-specific-heat`
 - Clojure Type: Double
 - Example: `0.2`
@@ -265,7 +267,7 @@ A non-negative IEEE-754 floating point number representing the specific heat of 
 A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Liter`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:tun-volume`
 - Clojure Type: Double
 - Example: `15.0`
@@ -275,7 +277,7 @@ A non-negative IEEE-754 floating point number representing the volume of the of 
 A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
 
 - BeerXML Type: `Floating Point`
-- BeerXML Units: `Kilogram`
+- BeerXML Unit: Kilogram
 - Clojure Key Name: `:tun-weight`
 - Clojure Type: Double
 - Example: `15.0`
@@ -284,6 +286,7 @@ A non-negative IEEE-754 floating point number representing the weight of the of 
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/equipment.md
+++ b/doc/specs/equipment.md
@@ -51,7 +51,7 @@ A record representing the brewing equipment used in brewing.
 - [Display Trub Chiller Loss](#display-trub-chiller-loss)
 - [Display Tun Volume](#display-tun-volume)
 - [Display Tun Weight](#display-tun-weight)
-- [Evap Rate](#evap-rate)
+- [Evaporation Rate](#evaporation-rate)
 - [Hop Utilization](#hop-utilization)
 - [Lauter Deadspace](#lauter-deadspace)
 - [Notes](#notes)
@@ -175,7 +175,7 @@ A non-empty string denoting a display value for the empty weight of the mash tun
 - Clojure Type: String
 - Example: `"5.5 pounds"`
 
-## Evap Rate
+## Evaporation Rate
 
 A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil.
 

--- a/doc/specs/equipment.md
+++ b/doc/specs/equipment.md
@@ -1,0 +1,253 @@
+# Equipment Records
+
+## Equipments Wrapper
+
+An ::equipment-wrapper record.
+
+### Wrapped Record
+
+- [Equipments](#equipments)
+
+## Equipments
+
+A vector of valid ::equipment-wrapper records.
+
+### Collection Type
+
+- [Equipment Wrapper](#equipment-wrapper)
+
+## Equipment Wrapper
+
+An ::equipment record wrapped in an ::equipment map.
+
+### Wrapped Record
+
+- [Equipment](#equipment)
+
+## Equipment
+
+A record representing the brewing equipment used in brewing.
+
+### Required Keys
+
+- [Batch Size](#batch-size)
+- [Boil Size](#boil-size)
+- [Name](#name)
+- [Version](#version)
+
+### Optional Keys
+
+- [Boil Time](#boil-time)
+- [Calculate Boil Volume](#calculate-boil-volume)
+- [Display Batch Size](#display-batch-size)
+- [Display Boil Size](#display-boil-size)
+- [Display Lauter Deadspace](#display-lauter-deadspace)
+- [Display Top Up Kettle](#display-top-up-kettle)
+- [Display Top Up Water](#display-top-up-water)
+- [Display Trub Chiller Loss](#display-trub-chiller-loss)
+- [Display Tun Volume](#display-tun-volume)
+- [Display Tun Weight](#display-tun-weight)
+- [Evap Rate](#evap-rate)
+- [Hop Utilization](#hop-utilization)
+- [Lauter Deadspace](#lauter-deadspace)
+- [Notes](#notes)
+- [Top Up Kettle](#top-up-kettle)
+- [Top Up Water](#top-up-water)
+- [Trub Chiller Loss](#trub-chiller-loss)
+- [Tun Specific Heat](#tun-specific-heat)
+- [Tun Volume](#tun-volume)
+- [Tun Weight](#tun-weight)
+
+## Batch Size
+
+A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation
+
+- Key Name: `:batch-size`
+- Type: Double
+- Example: `5.8`
+
+## Boil Size
+
+A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup
+
+- Key Name: `:boil-size`
+- Type: Double
+- Example: `10.8`
+
+## Boil Time
+
+A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss.
+
+- Key Name: `:boil-time`
+- Type: Double
+- Example: `15.0`
+
+## Calculate Boil Volume
+
+A boolean denoting whether or not programs reading this equipment record should calculate the boil size.
+When absent, assume false.
+When true, then boil-size = (batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)
+
+- Key Name: `:calc-boil-volume`
+- Type: Spec
+- Example: `true`
+
+## Display Batch Size
+
+A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units
+
+- Key Name: `:display-batch-size`
+- Type: String
+- Example: `"4.5 gallons"`
+
+## Display Boil Size
+
+A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units
+
+- Key Name: `:display-boil-size`
+- Type: String
+- Example: `"5.0 gallons"`
+
+## Display Lauter Deadspace
+
+A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units
+
+- Key Name: `:display-lauter-deadspace`
+- Type: String
+- Example: `"2.2 liters"`
+
+## Display Top Up Kettle
+
+A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units
+
+- Key Name: `:display-top-up-kettle`
+- Type: String
+- Example: `"2.2 liters"`
+
+## Display Top Up Water
+
+A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units
+
+- Key Name: `:display-top-up-water`
+- Type: String
+- Example: `"2.2 liters"`
+
+## Display Trub Chiller Loss
+
+A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units
+
+- Key Name: `:display-trub-chiller-loss`
+- Type: String
+- Example: `"2.2 liters"`
+
+## Display Tun Volume
+
+A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units
+
+- Key Name: `:display-tun-volume`
+- Type: String
+- Example: `"20 liters"`
+
+## Display Tun Weight
+
+A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units
+
+- Key Name: `:display-tun-weight`
+- Type: String
+- Example: `"5.5 pounds"`
+
+## Evap Rate
+
+A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil
+
+- Key Name: `:evap-rate`
+- Type: Double
+- Example: `1.2`
+
+## Hop Utilization
+
+A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization
+
+- Key Name: `:hop-utilization`
+- Type: Double
+- Example: `1.2`
+
+## Lauter Deadspace
+
+A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun
+
+- Key Name: `:lauter-deadspace`
+- Type: Double
+- Example: `0.1`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Top Up Kettle
+
+A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins
+
+- Key Name: `:top-up-kettle`
+- Type: Double
+- Example: `2.1`
+
+## Top Up Water
+
+A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters
+
+- Key Name: `:top-up-water`
+- Type: Double
+- Example: `2.1`
+
+## Trub Chiller Loss
+
+A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel
+
+- Key Name: `:trub-chiller-loss`
+- Type: Double
+- Example: `0.1`
+
+## Tun Specific Heat
+
+A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius
+
+- Key Name: `:tun-specific-heat`
+- Type: Double
+- Example: `0.2`
+
+## Tun Volume
+
+A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters
+
+- Key Name: `:tun-volume`
+- Type: Double
+- Example: `15.0`
+
+## Tun Weight
+
+A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms
+
+- Key Name: `:tun-weight`
+- Type: Double
+- Example: `15.0`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/equipment.md
+++ b/doc/specs/equipment.md
@@ -4,6 +4,8 @@
 
 An ::equipment-wrapper record.
 
+BeerXML Type: `Record Set`
+
 ### Wrapped Record
 
 - [Equipments](#equipments)
@@ -18,7 +20,9 @@ A vector of valid ::equipment-wrapper records.
 
 ## Equipment Wrapper
 
-An ::equipment record wrapped in an ::equipment map.
+An `::equipment` record wrapped in an `:equipment` map.
+
+BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -62,24 +66,30 @@ A record representing the brewing equipment used in brewing.
 
 A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation.
 
-- Key Name: `:batch-size`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:batch-size`
+- Clojure Type: Double
 - Example: `5.8`
 
 ## Boil Size
 
 A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup.
 
-- Key Name: `:boil-size`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:boil-size`
+- Clojure Type: Double
 - Example: `10.8`
 
 ## Boil Time
 
 A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss.
 
-- Key Name: `:boil-time`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Minute`
+- Clojure Key Name: `:boil-time`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Calculate Boil Volume
@@ -88,166 +98,192 @@ A boolean denoting whether or not programs reading this equipment record should 
 When absent, assume false.
 When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`
 
-- Key Name: `:calc-boil-volume`
-- Type: Spec
+- BeerXML Type: `Boolean`
+- Clojure Key Name: `:calc-boil-volume`
+- Clojure Type: Spec
 - Example: `true`
 
 ## Display Batch Size
 
 A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units.
 
-- Key Name: `:display-batch-size`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-batch-size`
+- Clojure Type: String
 - Example: `"4.5 gallons"`
 
 ## Display Boil Size
 
 A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units.
 
-- Key Name: `:display-boil-size`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-boil-size`
+- Clojure Type: String
 - Example: `"5.0 gallons"`
 
 ## Display Lauter Deadspace
 
 A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units.
 
-- Key Name: `:display-lauter-deadspace`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-lauter-deadspace`
+- Clojure Type: String
 - Example: `"2.2 liters"`
 
 ## Display Top Up Kettle
 
 A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units.
 
-- Key Name: `:display-top-up-kettle`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-top-up-kettle`
+- Clojure Type: String
 - Example: `"2.2 liters"`
 
 ## Display Top Up Water
 
 A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units.
 
-- Key Name: `:display-top-up-water`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-top-up-water`
+- Clojure Type: String
 - Example: `"2.2 liters"`
 
 ## Display Trub Chiller Loss
 
 A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units.
 
-- Key Name: `:display-trub-chiller-loss`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-trub-chiller-loss`
+- Clojure Type: String
 - Example: `"2.2 liters"`
 
 ## Display Tun Volume
 
 A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units.
 
-- Key Name: `:display-tun-volume`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-tun-volume`
+- Clojure Type: String
 - Example: `"20 liters"`
 
 ## Display Tun Weight
 
 A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units.
 
-- Key Name: `:display-tun-weight`
-- Type: String
+- BeerXML Type: `Text`
+- Clojure Key Name: `:display-tun-weight`
+- Clojure Type: String
 - Example: `"5.5 pounds"`
 
 ## Evap Rate
 
 A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil.
 
-- Key Name: `:evap-rate`
-- Type: Double
+- BeerXML Type: `Percentage`
+- BeerXML Units: `Percent per Hour`
+- Clojure Key Name: `:evap-rate`
+- Clojure Type: Double
 - Example: `1.2`
 
 ## Hop Utilization
 
 A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization.
 
-- Key Name: `:hop-utilization`
-- Type: Double
+- BeerXML Type: `Percentage`
+- Clojure Key Name: `:hop-utilization`
+- Clojure Type: Double
 - Example: `1.2`
 
 ## Lauter Deadspace
 
 A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun.
 
-- Key Name: `:lauter-deadspace`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:lauter-deadspace`
+- Clojure Type: Double
 - Example: `0.1`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Top Up Kettle
 
 A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins.
 
-- Key Name: `:top-up-kettle`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:top-up-kettle`
+- Clojure Type: Double
 - Example: `2.1`
 
 ## Top Up Water
 
 A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters.
 
-- Key Name: `:top-up-water`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:top-up-water`
+- Clojure Type: Double
 - Example: `2.1`
 
 ## Trub Chiller Loss
 
 A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel.
 
-- Key Name: `:trub-chiller-loss`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:trub-chiller-loss`
+- Clojure Type: Double
 - Example: `0.1`
 
 ## Tun Specific Heat
 
 A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
 
-- Key Name: `:tun-specific-heat`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Calories per Gram Degree Celsius`
+- Clojure Key Name: `:tun-specific-heat`
+- Clojure Type: Double
 - Example: `0.2`
 
 ## Tun Volume
 
 A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters.
 
-- Key Name: `:tun-volume`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Liter`
+- Clojure Key Name: `:tun-volume`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Tun Weight
 
 A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
 
-- Key Name: `:tun-weight`
-- Type: Double
+- BeerXML Type: `Floating Point`
+- BeerXML Units: `Kilogram`
+- Clojure Key Name: `:tun-weight`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/equipment.md
+++ b/doc/specs/equipment.md
@@ -60,7 +60,7 @@ A record representing the brewing equipment used in brewing.
 
 ## Batch Size
 
-A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation
+A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation.
 
 - Key Name: `:batch-size`
 - Type: Double
@@ -68,7 +68,7 @@ A non-negative IEEE-754 floating point number representing the target volume of 
 
 ## Boil Size
 
-A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup
+A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup.
 
 - Key Name: `:boil-size`
 - Type: Double
@@ -86,7 +86,7 @@ A non-negative IEEE-754 floating point number representing the normal amount of 
 
 A boolean denoting whether or not programs reading this equipment record should calculate the boil size.
 When absent, assume false.
-When true, then boil-size = (batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)
+When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`
 
 - Key Name: `:calc-boil-volume`
 - Type: Spec
@@ -94,7 +94,7 @@ When true, then boil-size = (batch-size - top-up-water - trub-chiller-loss) * (1
 
 ## Display Batch Size
 
-A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units
+A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units.
 
 - Key Name: `:display-batch-size`
 - Type: String
@@ -102,7 +102,7 @@ A non-empty string denoting a display value for the pre-permentation volume form
 
 ## Display Boil Size
 
-A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units
+A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units.
 
 - Key Name: `:display-boil-size`
 - Type: String
@@ -110,7 +110,7 @@ A non-empty string denoting a display value for the pre-boil volume formatted fo
 
 ## Display Lauter Deadspace
 
-A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units
+A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units.
 
 - Key Name: `:display-lauter-deadspace`
 - Type: String
@@ -118,7 +118,7 @@ A non-empty string denoting a display value for the volume of wort lost in the l
 
 ## Display Top Up Kettle
 
-A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units
+A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units.
 
 - Key Name: `:display-top-up-kettle`
 - Type: String
@@ -126,7 +126,7 @@ A non-empty string denoting a display value for the top-up water added to the pr
 
 ## Display Top Up Water
 
-A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units
+A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units.
 
 - Key Name: `:display-top-up-water`
 - Type: String
@@ -134,7 +134,7 @@ A non-empty string denoting a display value for the volume of top-up water added
 
 ## Display Trub Chiller Loss
 
-A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units
+A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units.
 
 - Key Name: `:display-trub-chiller-loss`
 - Type: String
@@ -142,7 +142,7 @@ A non-empty string denoting a display value for the volume of wort lost in trans
 
 ## Display Tun Volume
 
-A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units
+A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units.
 
 - Key Name: `:display-tun-volume`
 - Type: String
@@ -150,7 +150,7 @@ A non-empty string denoting a display value for the volume capacity of the mash 
 
 ## Display Tun Weight
 
-A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units
+A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units.
 
 - Key Name: `:display-tun-weight`
 - Type: String
@@ -158,7 +158,7 @@ A non-empty string denoting a display value for the empty weight of the mash tun
 
 ## Evap Rate
 
-A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil
+A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil.
 
 - Key Name: `:evap-rate`
 - Type: Double
@@ -166,7 +166,7 @@ A non-negative IEEE-754 floating point number representing the percentage of wor
 
 ## Hop Utilization
 
-A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization
+A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization.
 
 - Key Name: `:hop-utilization`
 - Type: Double
@@ -174,7 +174,7 @@ A non-negative IEEE-754 floating point number representing the percentage of lar
 
 ## Lauter Deadspace
 
-A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun
+A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun.
 
 - Key Name: `:lauter-deadspace`
 - Type: Double
@@ -198,7 +198,7 @@ A non-empty string representing any notes about the subject
 
 ## Top Up Kettle
 
-A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins
+A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins.
 
 - Key Name: `:top-up-kettle`
 - Type: Double
@@ -206,7 +206,7 @@ A non-negative IEEE-754 floating point number representing the volume of top-up 
 
 ## Top Up Water
 
-A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters
+A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters.
 
 - Key Name: `:top-up-water`
 - Type: Double
@@ -214,7 +214,7 @@ A non-negative IEEE-754 floating point number representing the volume of top-up 
 
 ## Trub Chiller Loss
 
-A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel
+A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel.
 
 - Key Name: `:trub-chiller-loss`
 - Type: Double
@@ -222,7 +222,7 @@ A non-negative IEEE-754 floating point number representing the volume of wort lo
 
 ## Tun Specific Heat
 
-A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius
+A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
 
 - Key Name: `:tun-specific-heat`
 - Type: Double
@@ -230,7 +230,7 @@ A non-negative IEEE-754 floating point number representing the specific heat of 
 
 ## Tun Volume
 
-A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters
+A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters.
 
 - Key Name: `:tun-volume`
 - Type: Double
@@ -238,7 +238,7 @@ A non-negative IEEE-754 floating point number representing the volume of the of 
 
 ## Tun Weight
 
-A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms
+A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
 
 - Key Name: `:tun-weight`
 - Type: Double

--- a/doc/specs/fermentables.md
+++ b/doc/specs/fermentables.md
@@ -2,7 +2,9 @@
 
 ## Fermentables Wrapper
 
-A `::fermentables-wrapper` record.
+A `::fermentables-wrapper` record set.
+
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -19,6 +21,8 @@ A vector of valid `::fermentable-wrapper` records.
 ## Fermentable Wrapper
 
 A `::fermentable` record wrapped in a `::fermentable` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -60,14 +64,19 @@ A record representing a fermentable ingredient in a beer recipe.
 A boolean representing if the fermentable was added after the boil.
 When absent, assume false.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:add-after-boil`
 - Clojure Type: Spec
 - Example: `false`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient.
+A value representing the amount of a particular ingredient.
+When measuring weight, this is in kilograms.
+When measuring volume, this is in liters.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Kilogram, Liter
 - Clojure Key Name: `:amount`
 - Clojure Type: Double
 - Example: `12.5`
@@ -77,6 +86,7 @@ A ::kilogram value representing the amount of a particular ingredient.
 A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:coarse-fine-diff`
 - Clojure Type: Double
 - Example: `0.856`
@@ -85,6 +95,8 @@ Only appropriate for the 'Grain' or 'Adjunct' types.
 
 A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Lovibond, SRM
 - Clojure Key Name: `:color`
 - Clojure Type: Double
 - Example: `32.0`
@@ -94,6 +106,7 @@ A non-negative IEEE-754 floating point number representing the color in Lovibond
 A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:diastatic-power`
 - Clojure Type: Double
 - Example: `0.65`
@@ -102,6 +115,7 @@ Only appropriate for the 'Grain' or 'Adjunct' types.
 
 A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-amount`
 - Clojure Type: String
 - Example: `"100 g"`
@@ -110,6 +124,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-color`
 - Clojure Type: String
 - Example: `"200 Lovibond"`
@@ -119,6 +134,7 @@ A non-empty string denoting a display value for the color of the ingredient form
 A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.
 Only appropriate for the 'Extract' type.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:ibu-gal-per-lb`
 - Clojure Type: Double
 - Example: `12.5`
@@ -127,6 +143,7 @@ Only appropriate for the 'Extract' type.
 
 A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:inventory`
 - Clojure Type: String
 - Example: `"100 lbs"`
@@ -135,6 +152,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:max-in-batch`
 - Clojure Type: Double
 - Example: `1.0`
@@ -144,14 +162,16 @@ A non-negative IEEE-754 floating point number representing the suggested maximum
 A non-negative IEEE-754 floating point number representing the percent moisture in the grain.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:moisture`
 - Clojure Type: Double
-- Example: `0.45`
+- Example: `45.0`
 
 ## Name
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -160,6 +180,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -168,6 +189,7 @@ A non-empty string representing any notes about the subject.
 
 A non-empty string denoting the place of origin for a particular ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:origin`
 - Clojure Type: String
 - Example: `"Nice, France"`
@@ -176,6 +198,8 @@ A non-empty string denoting the place of origin for a particular ingredient.
 
 A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:potential`
 - Clojure Type: Double
 - Example: `1.048`
@@ -185,9 +209,10 @@ A non-negative IEEE-754 floating point number representing the potential yield i
 A non-negative IEEE-754 floating point number representing the protein contents of the grain.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:protein`
 - Clojure Type: Double
-- Example: `0.1`
+- Example: `10.0`
 
 ## Recommend Mash
 
@@ -195,6 +220,7 @@ A boolean representing if the fermentable is recommended to be included in the m
 Only appropriate for the 'Grain' or 'Adjunct' types.
 When absent, assume false.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:recommend-mash`
 - Clojure Type: Spec
 - Example: `false`
@@ -203,6 +229,7 @@ When absent, assume false.
 
 A non-empty string denoting the supplier of the fermentable ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:supplier`
 - Clojure Type: String
 - Example: `"Gnome Brew"`
@@ -218,6 +245,7 @@ Must be one of: "Dry extract", "Sugar", "Adjunct", "Grain", "Extract"
 - Grain: Whole or milled barley, rye, wheat, or other grain.
 - Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"grain"`
@@ -226,6 +254,7 @@ Must be one of: "Dry extract", "Sugar", "Adjunct", "Grain", "Extract"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`
@@ -234,6 +263,7 @@ An integer representing the version of the BeerXML standard implemented in a giv
 
 A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:yield`
 - Clojure Type: Double
 - Example: `0.856`

--- a/doc/specs/fermentables.md
+++ b/doc/specs/fermentables.md
@@ -1,0 +1,239 @@
+# Fermentable Records
+
+## Fermentables Wrapper
+
+A `::fermentables-wrapper` record.
+
+### Wrapped Record
+
+- [Fermentables](#fermentables)
+
+## Fermentables
+
+A vector of valid `::fermentable-wrapper` records.
+
+### Collection Type
+
+- [Fermentable Wrapper](#fermentable-wrapper)
+
+## Fermentable Wrapper
+
+A `::fermentable` record wrapped in a `::fermentable` map.
+
+### Wrapped Record
+
+- [Fermentable](#fermentable)
+
+## Fermentable
+
+A record representing a fermentable ingredient in a beer recipe.
+
+### Required Keys
+
+- [Amount](#amount)
+- [Color](#color)
+- [Name](#name)
+- [Type](#type)
+- [Version](#version)
+- [Yield](#yield)
+
+### Optional Keys
+
+- [Add After Boil](#add-after-boil)
+- [Coarse Fine Difference](#coarse-fine-difference)
+- [Diastatic Power](#diastatic-power)
+- [Display Amount](#display-amount)
+- [Display Color](#display-color)
+- [Ibu Gal Per Lb](#ibu-gal-per-lb)
+- [Inventory](#inventory)
+- [Max In Batch](#max-in-batch)
+- [Moisture](#moisture)
+- [Notes](#notes)
+- [Origin](#origin)
+- [Potential](#potential)
+- [Protein](#protein)
+- [Recommend Mash](#recommend-mash)
+- [Supplier](#supplier)
+
+## Add After Boil
+
+A boolean representing if the fermentable was added after the boil.
+When absent, assume false.
+
+- Key Name: `:add-after-boil`
+- Type: Spec
+- Example: `false`
+
+## Amount
+
+A ::kilogram value representing the amount of a particular ingredient
+
+- Key Name: `:amount`
+- Type: Double
+- Example: `12.5`
+
+## Coarse Fine Difference
+
+A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield.
+Only appropriate for the 'Grain' or 'Adjunct' types.
+
+- Key Name: `:coarse-fine-diff`
+- Type: Double
+- Example: `0.856`
+
+## Color
+
+A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable.
+
+- Key Name: `:color`
+- Type: Double
+- Example: `32.0`
+
+## Diastatic Power
+
+A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.
+Only appropriate for the 'Grain' or 'Adjunct' types.
+
+- Key Name: `:diastatic-power`
+- Type: Double
+- Example: `0.65`
+
+## Display Amount
+
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+
+- Key Name: `:display-amount`
+- Type: String
+- Example: `"100 g"`
+
+## Display Color
+
+A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units.
+
+- Key Name: `:display-color`
+- Type: String
+- Example: `"200 Lovibond"`
+
+## Ibu Gal Per Lb
+
+A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.
+Only appropriate for the 'Extract' type.
+
+- Key Name: `:ibu-gal-per-lb`
+- Type: Double
+- Example: `12.5`
+
+## Inventory
+
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+
+- Key Name: `:inventory`
+- Type: String
+- Example: `"100 lbs"`
+
+## Max In Batch
+
+A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables.
+
+- Key Name: `:max-in-batch`
+- Type: Double
+- Example: `1.0`
+
+## Moisture
+
+A non-negative IEEE-754 floating point number representing the percent moisture in the grain.
+Only appropriate for the 'Grain' or 'Adjunct' types.
+
+- Key Name: `:moisture`
+- Type: Double
+- Example: `0.45`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Origin
+
+A non-empty string denoting the place of origin for a particular ingredient
+
+- Key Name: `:origin`
+- Type: String
+- Example: `"Nice, France"`
+
+## Potential
+
+A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient.
+
+- Key Name: `:potential`
+- Type: Double
+- Example: `1.048`
+
+## Protein
+
+A non-negative IEEE-754 floating point number representing the protein contents of the grain.
+Only appropriate for the 'Grain' or 'Adjunct' types.
+
+- Key Name: `:protein`
+- Type: Double
+- Example: `0.1`
+
+## Recommend Mash
+
+A boolean representing if the fermentable is recommended to be included in the mashing step.
+Only appropriate for the 'Grain' or 'Adjunct' types.
+When absent, assume false.
+
+- Key Name: `:recommend-mash`
+- Type: Spec
+- Example: `false`
+
+## Supplier
+
+A non-empty string denoting the supplier of the fermentable ingredient.
+
+- Key Name: `:supplier`
+- Type: String
+- Example: `"Gnome Brew"`
+
+## Type
+
+A case-insensitive string representing the form of the fermentable.
+Must be one of: "Sugar", "Grain", "Extract", "Dry extract", "Adjunct"
+
+- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars.
+- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley.
+- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form.
+- Grain: Whole or milled barley, rye, wheat, or other grain.
+- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)
+
+- Key Name: `:type`
+- Type: String
+- Example: `"grain"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`
+
+## Yield
+
+A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable.
+
+- Key Name: `:yield`
+- Type: Double
+- Example: `0.856`

--- a/doc/specs/fermentables.md
+++ b/doc/specs/fermentables.md
@@ -60,16 +60,16 @@ A record representing a fermentable ingredient in a beer recipe.
 A boolean representing if the fermentable was added after the boil.
 When absent, assume false.
 
-- Key Name: `:add-after-boil`
-- Type: Spec
+- Clojure Key Name: `:add-after-boil`
+- Clojure Type: Spec
 - Example: `false`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient
+A ::kilogram value representing the amount of a particular ingredient.
 
-- Key Name: `:amount`
-- Type: Double
+- Clojure Key Name: `:amount`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Coarse Fine Difference
@@ -77,16 +77,16 @@ A ::kilogram value representing the amount of a particular ingredient
 A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
-- Key Name: `:coarse-fine-diff`
-- Type: Double
+- Clojure Key Name: `:coarse-fine-diff`
+- Clojure Type: Double
 - Example: `0.856`
 
 ## Color
 
 A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable.
 
-- Key Name: `:color`
-- Type: Double
+- Clojure Key Name: `:color`
+- Clojure Type: Double
 - Example: `32.0`
 
 ## Diastatic Power
@@ -94,24 +94,24 @@ A non-negative IEEE-754 floating point number representing the color in Lovibond
 A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
-- Key Name: `:diastatic-power`
-- Type: Double
+- Clojure Key Name: `:diastatic-power`
+- Clojure Type: Double
 - Example: `0.65`
 
 ## Display Amount
 
-A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
-- Key Name: `:display-amount`
-- Type: String
+- Clojure Key Name: `:display-amount`
+- Clojure Type: String
 - Example: `"100 g"`
 
 ## Display Color
 
 A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units.
 
-- Key Name: `:display-color`
-- Type: String
+- Clojure Key Name: `:display-color`
+- Clojure Type: String
 - Example: `"200 Lovibond"`
 
 ## Ibu Gal Per Lb
@@ -119,24 +119,24 @@ A non-empty string denoting a display value for the color of the ingredient form
 A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil.
 Only appropriate for the 'Extract' type.
 
-- Key Name: `:ibu-gal-per-lb`
-- Type: Double
+- Clojure Key Name: `:ibu-gal-per-lb`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Inventory
 
-A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
-- Key Name: `:inventory`
-- Type: String
+- Clojure Key Name: `:inventory`
+- Clojure Type: String
 - Example: `"100 lbs"`
 
 ## Max In Batch
 
 A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables.
 
-- Key Name: `:max-in-batch`
-- Type: Double
+- Clojure Key Name: `:max-in-batch`
+- Clojure Type: Double
 - Example: `1.0`
 
 ## Moisture
@@ -144,40 +144,40 @@ A non-negative IEEE-754 floating point number representing the suggested maximum
 A non-negative IEEE-754 floating point number representing the percent moisture in the grain.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
-- Key Name: `:moisture`
-- Type: Double
+- Clojure Key Name: `:moisture`
+- Clojure Type: Double
 - Example: `0.45`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Origin
 
-A non-empty string denoting the place of origin for a particular ingredient
+A non-empty string denoting the place of origin for a particular ingredient.
 
-- Key Name: `:origin`
-- Type: String
+- Clojure Key Name: `:origin`
+- Clojure Type: String
 - Example: `"Nice, France"`
 
 ## Potential
 
 A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient.
 
-- Key Name: `:potential`
-- Type: Double
+- Clojure Key Name: `:potential`
+- Clojure Type: Double
 - Example: `1.048`
 
 ## Protein
@@ -185,8 +185,8 @@ A non-negative IEEE-754 floating point number representing the potential yield i
 A non-negative IEEE-754 floating point number representing the protein contents of the grain.
 Only appropriate for the 'Grain' or 'Adjunct' types.
 
-- Key Name: `:protein`
-- Type: Double
+- Clojure Key Name: `:protein`
+- Clojure Type: Double
 - Example: `0.1`
 
 ## Recommend Mash
@@ -195,22 +195,22 @@ A boolean representing if the fermentable is recommended to be included in the m
 Only appropriate for the 'Grain' or 'Adjunct' types.
 When absent, assume false.
 
-- Key Name: `:recommend-mash`
-- Type: Spec
+- Clojure Key Name: `:recommend-mash`
+- Clojure Type: Spec
 - Example: `false`
 
 ## Supplier
 
 A non-empty string denoting the supplier of the fermentable ingredient.
 
-- Key Name: `:supplier`
-- Type: String
+- Clojure Key Name: `:supplier`
+- Clojure Type: String
 - Example: `"Gnome Brew"`
 
 ## Type
 
-A case-insensitive string representing the form of the fermentable.
-Must be one of: "Sugar", "Grain", "Extract", "Dry extract", "Adjunct"
+A case-sensitive string representing the form of the fermentable.
+Must be one of: "Dry extract", "Sugar", "Adjunct", "Grain", "Extract"
 
 - Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars.
 - Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley.
@@ -218,22 +218,22 @@ Must be one of: "Sugar", "Grain", "Extract", "Dry extract", "Adjunct"
 - Grain: Whole or milled barley, rye, wheat, or other grain.
 - Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"grain"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`
 
 ## Yield
 
 A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable.
 
-- Key Name: `:yield`
-- Type: Double
+- Clojure Key Name: `:yield`
+- Clojure Type: Double
 - Example: `0.856`

--- a/doc/specs/hops.md
+++ b/doc/specs/hops.md
@@ -58,133 +58,133 @@ A record representing a hop in a beer recipe.
 
 A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop.
 
-- Key Name: `:alpha`
-- Type: Double
+- Clojure Key Name: `:alpha`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient
+A ::kilogram value representing the amount of a particular ingredient.
 
-- Key Name: `:amount`
-- Type: Double
+- Clojure Key Name: `:amount`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Beta
 
 A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop.
 
-- Key Name: `:beta`
-- Type: Double
+- Clojure Key Name: `:beta`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Caryophyllene
 
 A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop.
 
-- Key Name: `:caryophyllene`
-- Type: Double
+- Clojure Key Name: `:caryophyllene`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Cohumulone
 
 A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop.
 
-- Key Name: `:cohumulone`
-- Type: Double
+- Clojure Key Name: `:cohumulone`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Display Amount
 
-A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
-- Key Name: `:display-amount`
-- Type: String
+- Clojure Key Name: `:display-amount`
+- Clojure Type: String
 - Example: `"100 g"`
 
 ## Display Time
 
-A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units
+A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units.
 
-- Key Name: `:display-time`
-- Type: String
+- Clojure Key Name: `:display-time`
+- Clojure Type: String
 - Example: `"10 days"`
 
 ## Form
 
-A case-insensitive string representing the physical form of the hop.
-Must be one of: "Leaf", "Plug", "Pellet"
+A case-sensitive string representing the physical form of the hop.
+Must be one of: "Pellet", "Leaf", "Plug"
 
 - Pellet: Ground and compressed hop cones.
 - Plug: Whole hop cones compressed into plugs.
 - Leaf: Whole hop cones.
 
-- Key Name: `:form`
-- Type: String
+- Clojure Key Name: `:form`
+- Clojure Type: String
 - Example: `"leaf"`
 
 ## Hop Stability Index
 
 A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months.
 
-- Key Name: `:hsi`
-- Type: Double
+- Clojure Key Name: `:hsi`
+- Clojure Type: Double
 - Example: `2.2`
 
 ## Humulene
 
 A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop.
 
-- Key Name: `:humulene`
-- Type: Double
+- Clojure Key Name: `:humulene`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Inventory
 
-A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
-- Key Name: `:inventory`
-- Type: String
+- Clojure Key Name: `:inventory`
+- Clojure Type: String
 - Example: `"100 lbs"`
 
 ## Myrcene
 
 A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop.
 
-- Key Name: `:myrcene`
-- Type: Double
+- Clojure Key Name: `:myrcene`
+- Clojure Type: Double
 - Example: `10.7`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Origin
 
-A non-empty string denoting the place of origin for a particular ingredient
+A non-empty string denoting the place of origin for a particular ingredient.
 
-- Key Name: `:origin`
-- Type: String
+- Clojure Key Name: `:origin`
+- Clojure Type: String
 - Example: `"Nice, France"`
 
 ## Substitutes
 
-A non-empty string denoting ingredients with me bay used in place of those denoted in the record
+A non-empty string denoting ingredients with me bay used in place of those denoted in the record.
 
-- Key Name: `:substitutes`
-- Type: String
+- Clojure Key Name: `:substitutes`
+- Clojure Type: String
 - Example: `"Citra or Sorachi"`
 
 ## Time
@@ -197,27 +197,27 @@ A non-negative IEEE-754 floating point number representing the time in minutes t
 - Aroma: this is the steep time.
 - Dry Hop: this is the amount of time to dry hop.
 
-- Key Name: `:time`
-- Type: Double
+- Clojure Key Name: `:time`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Type
 
-A case-insensitive string representing the typical purpose of the hop's addition to a beer.
-Must be one of: "Aroma", "Both", "Bittering"
+A case-sensitive string representing the typical purpose of the hop's addition to a beer.
+Must be one of: "Both", "Aroma", "Bittering"
 
 - Bittering: Hops added solely for their bittering properties.
 - Aroma: Hops added solely for their aromatic properties and flavor.
 - Both: Hops which may be added for both/either their bittering and/or aromatic properties.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"bittering"`
 
 ## Use
 
-A case-insensitive string representing the means by which the hop is added to the beer.
-Must be one of: "Aroma", "Boil", "First wort", "Dry hop", "Mash"
+A case-sensitive string representing the means by which the hop is added to the beer.
+Must be one of: "Mash", "Boil", "Dry hop", "First wort", "Aroma"
 
 - Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer.
 - Boil: Hops added to the boil for bittering.
@@ -225,14 +225,14 @@ Must be one of: "Aroma", "Boil", "First wort", "Dry hop", "Mash"
 - First Wort: Hops added to first wort prior to the boil.
 - Mash: Hops added to the mash prior to the boil.
 
-- Key Name: `:use`
-- Type: String
+- Clojure Key Name: `:use`
+- Clojure Type: String
 - Example: `"mash"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/hops.md
+++ b/doc/specs/hops.md
@@ -2,7 +2,9 @@
 
 ## Hops Wrapper
 
-A `::hops-wrapper` record.
+A `::hops-wrapper` record set.
+
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -19,6 +21,8 @@ A vector of valid `::hop-wrapper` records.
 ## Hop Wrapper
 
 A `::hop` record wrapped in a `:hop` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -58,14 +62,19 @@ A record representing a hop in a beer recipe.
 
 A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:alpha`
 - Clojure Type: Double
 - Example: `10.7`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient.
+A value representing the amount of a particular ingredient.
+When measuring weight, this is in kilograms.
+When measuring volume, this is in liters.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Kilogram, Liter
 - Clojure Key Name: `:amount`
 - Clojure Type: Double
 - Example: `12.5`
@@ -74,6 +83,7 @@ A ::kilogram value representing the amount of a particular ingredient.
 
 A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:beta`
 - Clojure Type: Double
 - Example: `10.7`
@@ -82,6 +92,7 @@ A non-negative IEEE-754 floating point number representing the percent contents 
 
 A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:caryophyllene`
 - Clojure Type: Double
 - Example: `10.7`
@@ -90,6 +101,7 @@ A non-negative IEEE-754 floating point number representing the percent contents 
 
 A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:cohumulone`
 - Clojure Type: Double
 - Example: `10.7`
@@ -98,6 +110,7 @@ A non-negative IEEE-754 floating point number representing the percent contents 
 
 A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-amount`
 - Clojure Type: String
 - Example: `"100 g"`
@@ -106,6 +119,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-time`
 - Clojure Type: String
 - Example: `"10 days"`
@@ -119,6 +133,7 @@ Must be one of: "Pellet", "Leaf", "Plug"
 - Plug: Whole hop cones compressed into plugs.
 - Leaf: Whole hop cones.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:form`
 - Clojure Type: String
 - Example: `"leaf"`
@@ -127,6 +142,7 @@ Must be one of: "Pellet", "Leaf", "Plug"
 
 A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:hsi`
 - Clojure Type: Double
 - Example: `2.2`
@@ -135,6 +151,7 @@ A non-negative IEEE-754 floating point number representing the Hop Stability Ind
 
 A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:humulene`
 - Clojure Type: Double
 - Example: `10.7`
@@ -143,6 +160,7 @@ A non-negative IEEE-754 floating point number representing the percent contents 
 
 A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:inventory`
 - Clojure Type: String
 - Example: `"100 lbs"`
@@ -151,6 +169,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:myrcene`
 - Clojure Type: Double
 - Example: `10.7`
@@ -159,6 +178,7 @@ A non-negative IEEE-754 floating point number representing the percent contents 
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -167,6 +187,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -175,6 +196,7 @@ A non-empty string representing any notes about the subject.
 
 A non-empty string denoting the place of origin for a particular ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:origin`
 - Clojure Type: String
 - Example: `"Nice, France"`
@@ -183,13 +205,14 @@ A non-empty string denoting the place of origin for a particular ingredient.
 
 A non-empty string denoting ingredients with me bay used in place of those denoted in the record.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:substitutes`
 - Clojure Type: String
 - Example: `"Citra or Sorachi"`
 
 ## Time
 
-A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field.
+A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the `:use` field.
 
 - Boil: this is the boil time.
 - Mash: this is the mash time.
@@ -197,6 +220,8 @@ A non-negative IEEE-754 floating point number representing the time in minutes t
 - Aroma: this is the steep time.
 - Dry Hop: this is the amount of time to dry hop.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:time`
 - Clojure Type: Double
 - Example: `15.0`
@@ -210,6 +235,7 @@ Must be one of: "Both", "Aroma", "Bittering"
 - Aroma: Hops added solely for their aromatic properties and flavor.
 - Both: Hops which may be added for both/either their bittering and/or aromatic properties.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"bittering"`
@@ -225,6 +251,7 @@ Must be one of: "Mash", "Boil", "Dry hop", "First wort", "Aroma"
 - First Wort: Hops added to first wort prior to the boil.
 - Mash: Hops added to the mash prior to the boil.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:use`
 - Clojure Type: String
 - Example: `"mash"`
@@ -233,6 +260,7 @@ Must be one of: "Mash", "Boil", "Dry hop", "First wort", "Aroma"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/hops.md
+++ b/doc/specs/hops.md
@@ -1,0 +1,238 @@
+# Hop Records
+
+## Hops Wrapper
+
+A `::hops-wrapper` record.
+
+### Wrapped Record
+
+- [Hops](#hops)
+
+## Hops
+
+A vector of valid `::hop-wrapper` records.
+
+### Collection Type
+
+- [Hop Wrapper](#hop-wrapper)
+
+## Hop Wrapper
+
+A `::hop` record wrapped in a `:hop` map.
+
+### Wrapped Record
+
+- [Hop](#hop)
+
+## Hop
+
+A record representing a hop in a beer recipe.
+
+### Required Keys
+
+- [Alpha](#alpha)
+- [Amount](#amount)
+- [Name](#name)
+- [Time](#time)
+- [Use](#use)
+- [Version](#version)
+
+### Optional Keys
+
+- [Beta](#beta)
+- [Caryophyllene](#caryophyllene)
+- [Cohumulone](#cohumulone)
+- [Display Amount](#display-amount)
+- [Display Time](#display-time)
+- [Form](#form)
+- [Hop Stability Index](#hop-stability-index)
+- [Humulene](#humulene)
+- [Inventory](#inventory)
+- [Myrcene](#myrcene)
+- [Notes](#notes)
+- [Origin](#origin)
+- [Substitutes](#substitutes)
+- [Type](#type)
+
+## Alpha
+
+A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop.
+
+- Key Name: `:alpha`
+- Type: Double
+- Example: `10.7`
+
+## Amount
+
+A ::kilogram value representing the amount of a particular ingredient
+
+- Key Name: `:amount`
+- Type: Double
+- Example: `12.5`
+
+## Beta
+
+A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop.
+
+- Key Name: `:beta`
+- Type: Double
+- Example: `10.7`
+
+## Caryophyllene
+
+A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop.
+
+- Key Name: `:caryophyllene`
+- Type: Double
+- Example: `10.7`
+
+## Cohumulone
+
+A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop.
+
+- Key Name: `:cohumulone`
+- Type: Double
+- Example: `10.7`
+
+## Display Amount
+
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+
+- Key Name: `:display-amount`
+- Type: String
+- Example: `"100 g"`
+
+## Display Time
+
+A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units
+
+- Key Name: `:display-time`
+- Type: String
+- Example: `"10 days"`
+
+## Form
+
+A case-insensitive string representing the physical form of the hop.
+Must be one of: "Leaf", "Plug", "Pellet"
+
+- Pellet: Ground and compressed hop cones.
+- Plug: Whole hop cones compressed into plugs.
+- Leaf: Whole hop cones.
+
+- Key Name: `:form`
+- Type: String
+- Example: `"leaf"`
+
+## Hop Stability Index
+
+A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months.
+
+- Key Name: `:hsi`
+- Type: Double
+- Example: `2.2`
+
+## Humulene
+
+A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop.
+
+- Key Name: `:humulene`
+- Type: Double
+- Example: `10.7`
+
+## Inventory
+
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+
+- Key Name: `:inventory`
+- Type: String
+- Example: `"100 lbs"`
+
+## Myrcene
+
+A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop.
+
+- Key Name: `:myrcene`
+- Type: Double
+- Example: `10.7`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Origin
+
+A non-empty string denoting the place of origin for a particular ingredient
+
+- Key Name: `:origin`
+- Type: String
+- Example: `"Nice, France"`
+
+## Substitutes
+
+A non-empty string denoting ingredients with me bay used in place of those denoted in the record
+
+- Key Name: `:substitutes`
+- Type: String
+- Example: `"Citra or Sorachi"`
+
+## Time
+
+A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field.
+
+- Boil: this is the boil time.
+- Mash: this is the mash time.
+- First Wort: this is the boil time.
+- Aroma: this is the steep time.
+- Dry Hop: this is the amount of time to dry hop.
+
+- Key Name: `:time`
+- Type: Double
+- Example: `15.0`
+
+## Type
+
+A case-insensitive string representing the typical purpose of the hop's addition to a beer.
+Must be one of: "Aroma", "Both", "Bittering"
+
+- Bittering: Hops added solely for their bittering properties.
+- Aroma: Hops added solely for their aromatic properties and flavor.
+- Both: Hops which may be added for both/either their bittering and/or aromatic properties.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"bittering"`
+
+## Use
+
+A case-insensitive string representing the means by which the hop is added to the beer.
+Must be one of: "Aroma", "Boil", "First wort", "Dry hop", "Mash"
+
+- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer.
+- Boil: Hops added to the boil for bittering.
+- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer.
+- First Wort: Hops added to first wort prior to the boil.
+- Mash: Hops added to the mash prior to the boil.
+
+- Key Name: `:use`
+- Type: String
+- Example: `"mash"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/mash.md
+++ b/doc/specs/mash.md
@@ -187,7 +187,7 @@ An integer representing the version of the BeerXML standard implemented in a giv
 
 ## Mash Steps
 
-A `::mash-step` record set
+A `::mash-step` record set.
 
 ### Collection Type
 

--- a/doc/specs/mash.md
+++ b/doc/specs/mash.md
@@ -27,7 +27,7 @@ A record representing the mashing process.
 - [Display Tun Weight](#display-tun-weight)
 - [Equip Adjust](#equip-adjust)
 - [Notes](#notes)
-- [Ph](#ph)
+- [PH](#ph)
 - [Sparge Temperature](#sparge-temperature)
 - [Tun Specific Heat](#tun-specific-heat)
 - [Tun Temperature](#tun-temperature)
@@ -98,7 +98,7 @@ A non-empty string representing any notes about the subject
 - Type: String
 - Example: `"A wonderful, zesty aroma"`
 
-## Ph
+## PH
 
 A non-negative IEEE-754 floating point number representing the PH of the water.
 

--- a/doc/specs/mash.md
+++ b/doc/specs/mash.md
@@ -37,32 +37,32 @@ A record representing the mashing process.
 
 A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units.
 
-- Key Name: `:display-grain-temp`
-- Type: String
+- Clojure Key Name: `:display-grain-temp`
+- Clojure Type: String
 - Example: `"72F"`
 
 ## Display Sparge Temperature
 
 A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units.
 
-- Key Name: `:display-sparge-temp`
-- Type: String
+- Clojure Key Name: `:display-sparge-temp`
+- Clojure Type: String
 - Example: `"172F"`
 
 ## Display Tun Temperature
 
 A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units.
 
-- Key Name: `:display-tun-temp`
-- Type: String
+- Clojure Key Name: `:display-tun-temp`
+- Clojure Type: String
 - Example: `"72F"`
 
 ## Display Tun Weight
 
 A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units.
 
-- Key Name: `:display-tun-weight`
-- Type: String
+- Clojure Key Name: `:display-tun-weight`
+- Clojure Type: String
 - Example: `"72lbs"`
 
 ## Equip Adjust
@@ -70,80 +70,80 @@ A non-empty string denoting a display value for mash tun weight formatted for di
 A boolean denoting whether or not programs should account for the temperature effects of the equipment used.
 When absent, assume false.
 
-- Key Name: `:equip-adjust`
-- Type: Spec
+- Clojure Key Name: `:equip-adjust`
+- Clojure Type: Spec
 - Example: `true`
 
 ## Grain Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius.
 
-- Key Name: `:grain-temp`
-- Type: Double
+- Clojure Key Name: `:grain-temp`
+- Clojure Type: Double
 - Example: `80.0`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## PH
 
 A non-negative IEEE-754 floating point number representing the PH of the water.
 
-- Key Name: `:ph`
-- Type: Double
+- Clojure Key Name: `:ph`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Sparge Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius.
 
-- Key Name: `:sparge-temp`
-- Type: Double
+- Clojure Key Name: `:sparge-temp`
+- Clojure Type: Double
 - Example: `50.0`
 
 ## Tun Specific Heat
 
 A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
 
-- Key Name: `:tun-specific-heat`
-- Type: Double
+- Clojure Key Name: `:tun-specific-heat`
+- Clojure Type: Double
 - Example: `0.2`
 
 ## Tun Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius.
 
-- Key Name: `:tun-temp`
-- Type: Double
+- Clojure Key Name: `:tun-temp`
+- Clojure Type: Double
 - Example: `80.0`
 
 ## Tun Weight
 
 A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
 
-- Key Name: `:tun-weight`
-- Type: Double
+- Clojure Key Name: `:tun-weight`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`
 
 ## Mash Steps
@@ -190,115 +190,115 @@ A record representing a step within the mashing process.
 
 A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units.
 
-- Key Name: `:decoction-amt`
-- Type: String
+- Clojure Key Name: `:decoction-amt`
+- Clojure Type: String
 - Example: `"7.5 liters"`
 
 ## Description
 
 A non-empty string describing the mash step.
 
-- Key Name: `:description`
-- Type: String
+- Clojure Key Name: `:description`
+- Clojure Type: String
 - Example: `"Stir your grain bag carefully at 140F."`
 
 ## Display Infusion Amount
 
 A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units.
 
-- Key Name: `:display-infuse-amt`
-- Type: String
+- Clojure Key Name: `:display-infuse-amt`
+- Clojure Type: String
 - Example: `"2.2L"`
 
 ## Display Step Temperature
 
 A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units.
 
-- Key Name: `:display-step-temp`
-- Type: String
+- Clojure Key Name: `:display-step-temp`
+- Clojure Type: String
 - Example: `"150F"`
 
 ## End Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius.
 
-- Key Name: `:end-temp`
-- Type: Double
+- Clojure Key Name: `:end-temp`
+- Clojure Type: Double
 - Example: `80.0`
 
 ## Infuse Amount
 
 A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step.
 
-- Key Name: `:infuse-amount`
-- Type: Double
+- Clojure Key Name: `:infuse-amount`
+- Clojure Type: Double
 - Example: `5.8`
 
 ## Infusion Temperature
 
 A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units.
 
-- Key Name: `:infuse-temp`
-- Type: String
+- Clojure Key Name: `:infuse-temp`
+- Clojure Type: String
 - Example: `"150F"`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Ramp Time
 
 A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature.
 
-- Key Name: `:ramp-time`
-- Type: Double
+- Clojure Key Name: `:ramp-time`
+- Clojure Type: Double
 - Example: `45.0`
 
 ## Step Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius.
 
-- Key Name: `:step-temp`
-- Type: Double
+- Clojure Key Name: `:step-temp`
+- Clojure Type: Double
 - Example: `80.0`
 
 ## Step Time
 
 A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step.
 
-- Key Name: `:step-time`
-- Type: Double
+- Clojure Key Name: `:step-time`
+- Clojure Type: Double
 - Example: `45.0`
 
 ## Type
 
-A case-insensitive string representing the type of mash step.
-Must be one of: "Infusion", "Temperature", "Decoction"
+A case-sensitive string representing the type of mash step.
+Must be one of: "Decoction", "Temperature", "Infusion"
 
 - Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun.
 - Infusion: A mash step where fermentable ingredients steep in water at a specific temperature.
 - Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"Temperature"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`
 
 ## Water Grain Ratio
 
 A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units.
 
-- Key Name: `:water-grain-ratio`
-- Type: String
+- Clojure Key Name: `:water-grain-ratio`
+- Clojure Type: String
 - Example: `"1.5qt/lb"`

--- a/doc/specs/mash.md
+++ b/doc/specs/mash.md
@@ -1,0 +1,304 @@
+# Mash Records
+
+## Mash Wrapper
+
+A `::mash-wrapper` record
+
+### Wrapped Record
+
+- [Mash](#mash)
+
+## Mash
+
+A record representing the mashing process.
+
+### Required Keys
+
+- [Grain Temperature](#grain-temperature)
+- [Mash Steps](#mash-steps)
+- [Name](#name)
+- [Version](#version)
+
+### Optional Keys
+
+- [Display Grain Temperature](#display-grain-temperature)
+- [Display Sparge Temperature](#display-sparge-temperature)
+- [Display Tun Temperature](#display-tun-temperature)
+- [Display Tun Weight](#display-tun-weight)
+- [Equip Adjust](#equip-adjust)
+- [Notes](#notes)
+- [Ph](#ph)
+- [Sparge Temperature](#sparge-temperature)
+- [Tun Specific Heat](#tun-specific-heat)
+- [Tun Temperature](#tun-temperature)
+- [Tun Weight](#tun-weight)
+
+## Display Grain Temperature
+
+A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units.
+
+- Key Name: `:display-grain-temp`
+- Type: String
+- Example: `"72F"`
+
+## Display Sparge Temperature
+
+A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units.
+
+- Key Name: `:display-sparge-temp`
+- Type: String
+- Example: `"172F"`
+
+## Display Tun Temperature
+
+A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units.
+
+- Key Name: `:display-tun-temp`
+- Type: String
+- Example: `"72F"`
+
+## Display Tun Weight
+
+A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units.
+
+- Key Name: `:display-tun-weight`
+- Type: String
+- Example: `"72lbs"`
+
+## Equip Adjust
+
+A boolean denoting whether or not programs should account for the temperature effects of the equipment used.
+When absent, assume false.
+
+- Key Name: `:equip-adjust`
+- Type: Spec
+- Example: `true`
+
+## Grain Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius.
+
+- Key Name: `:grain-temp`
+- Type: Double
+- Example: `80.0`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Ph
+
+A non-negative IEEE-754 floating point number representing the PH of the water.
+
+- Key Name: `:ph`
+- Type: Double
+- Example: `2.5`
+
+## Sparge Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius.
+
+- Key Name: `:sparge-temp`
+- Type: Double
+- Example: `50.0`
+
+## Tun Specific Heat
+
+A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
+
+- Key Name: `:tun-specific-heat`
+- Type: Double
+- Example: `0.2`
+
+## Tun Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius.
+
+- Key Name: `:tun-temp`
+- Type: Double
+- Example: `80.0`
+
+## Tun Weight
+
+A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
+
+- Key Name: `:tun-weight`
+- Type: Double
+- Example: `15.0`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`
+
+## Mash Steps
+
+A vector of valid `::mash-step` records
+
+### Collection Type
+
+- [Mash Step Wrapper](#mash-step-wrapper)
+
+## Mash Step Wrapper
+
+A `::mash` record wrapped in a `:mash` map
+
+### Wrapped Record
+
+- [Mash Step](#mash-step)
+
+## Mash Step
+
+A record representing a step within the mashing process.
+
+### Required Keys
+
+- [Infuse Amount](#infuse-amount)
+- [Name](#name)
+- [Step Temperature](#step-temperature)
+- [Step Time](#step-time)
+- [Type](#type)
+- [Version](#version)
+
+### Optional Keys
+
+- [Decoction Amount](#decoction-amount)
+- [Description](#description)
+- [Display Infusion Amount](#display-infusion-amount)
+- [Display Step Temperature](#display-step-temperature)
+- [End Temperature](#end-temperature)
+- [Infusion Temperature](#infusion-temperature)
+- [Ramp Time](#ramp-time)
+- [Water Grain Ratio](#water-grain-ratio)
+
+## Decoction Amount
+
+A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units.
+
+- Key Name: `:decoction-amt`
+- Type: String
+- Example: `"7.5 liters"`
+
+## Description
+
+A non-empty string describing the mash step.
+
+- Key Name: `:description`
+- Type: String
+- Example: `"Stir your grain bag carefully at 140F."`
+
+## Display Infusion Amount
+
+A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units.
+
+- Key Name: `:display-infuse-amt`
+- Type: String
+- Example: `"2.2L"`
+
+## Display Step Temperature
+
+A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units.
+
+- Key Name: `:display-step-temp`
+- Type: String
+- Example: `"150F"`
+
+## End Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius.
+
+- Key Name: `:end-temp`
+- Type: Double
+- Example: `80.0`
+
+## Infuse Amount
+
+A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step.
+
+- Key Name: `:infuse-amount`
+- Type: Double
+- Example: `5.8`
+
+## Infusion Temperature
+
+A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units.
+
+- Key Name: `:infuse-temp`
+- Type: String
+- Example: `"150F"`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Ramp Time
+
+A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature.
+
+- Key Name: `:ramp-time`
+- Type: Double
+- Example: `45.0`
+
+## Step Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius.
+
+- Key Name: `:step-temp`
+- Type: Double
+- Example: `80.0`
+
+## Step Time
+
+A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step.
+
+- Key Name: `:step-time`
+- Type: Double
+- Example: `45.0`
+
+## Type
+
+A case-insensitive string representing the type of mash step.
+Must be one of: "Infusion", "Temperature", "Decoction"
+
+- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun.
+- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature.
+- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"Temperature"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`
+
+## Water Grain Ratio
+
+A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units.
+
+- Key Name: `:water-grain-ratio`
+- Type: String
+- Example: `"1.5qt/lb"`

--- a/doc/specs/mash.md
+++ b/doc/specs/mash.md
@@ -1,8 +1,28 @@
 # Mash Records
 
+## Mashs Wrapper
+
+A `::mashs` record record set.
+
+- BeerXML Type: `Record Set`
+
+### Wrapped Record
+
+- [Mashs](#mashs)
+
+## Mashs
+
+A vector of valid `::mash` records.
+
+### Collection Type
+
+- [Mash Wrapper](#mash-wrapper)
+
 ## Mash Wrapper
 
 A `::mash-wrapper` record
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -25,7 +45,7 @@ A record representing the mashing process.
 - [Display Sparge Temperature](#display-sparge-temperature)
 - [Display Tun Temperature](#display-tun-temperature)
 - [Display Tun Weight](#display-tun-weight)
-- [Equip Adjust](#equip-adjust)
+- [Equipment Adjust](#equipment-adjust)
 - [Notes](#notes)
 - [PH](#ph)
 - [Sparge Temperature](#sparge-temperature)
@@ -37,6 +57,7 @@ A record representing the mashing process.
 
 A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-grain-temp`
 - Clojure Type: String
 - Example: `"72F"`
@@ -45,6 +66,7 @@ A non-empty string denoting a display value for grain temperature formatted for 
 
 A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-sparge-temp`
 - Clojure Type: String
 - Example: `"172F"`
@@ -53,6 +75,7 @@ A non-empty string denoting a display value for sparging process temperature for
 
 A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-tun-temp`
 - Clojure Type: String
 - Example: `"72F"`
@@ -61,15 +84,17 @@ A non-empty string denoting a display value for mash tun temperature formatted f
 
 A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-tun-weight`
 - Clojure Type: String
 - Example: `"72lbs"`
 
-## Equip Adjust
+## Equipment Adjust
 
 A boolean denoting whether or not programs should account for the temperature effects of the equipment used.
 When absent, assume false.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:equip-adjust`
 - Clojure Type: Spec
 - Example: `true`
@@ -78,6 +103,8 @@ When absent, assume false.
 
 A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:grain-temp`
 - Clojure Type: Double
 - Example: `80.0`
@@ -86,6 +113,7 @@ A non-negative IEEE-754 floating point number representing the temperature of th
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -94,6 +122,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -102,6 +131,7 @@ A non-empty string representing any notes about the subject.
 
 A non-negative IEEE-754 floating point number representing the PH of the water.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:ph`
 - Clojure Type: Double
 - Example: `2.5`
@@ -110,6 +140,8 @@ A non-negative IEEE-754 floating point number representing the PH of the water.
 
 A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:sparge-temp`
 - Clojure Type: Double
 - Example: `50.0`
@@ -118,6 +150,8 @@ A non-negative IEEE-754 floating point number representing the temperature of th
 
 A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Calories per Gram Degree Celsius
 - Clojure Key Name: `:tun-specific-heat`
 - Clojure Type: Double
 - Example: `0.2`
@@ -126,6 +160,8 @@ A non-negative IEEE-754 floating point number representing the specific heat of 
 
 A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:tun-temp`
 - Clojure Type: Double
 - Example: `80.0`
@@ -134,6 +170,8 @@ A non-negative IEEE-754 floating point number representing the temperature of th
 
 A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Kilogram
 - Clojure Key Name: `:tun-weight`
 - Clojure Type: Double
 - Example: `15.0`
@@ -142,13 +180,14 @@ A non-negative IEEE-754 floating point number representing the weight of the of 
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`
 
 ## Mash Steps
 
-A vector of valid `::mash-step` records
+A `::mash-step` record set
 
 ### Collection Type
 
@@ -157,6 +196,8 @@ A vector of valid `::mash-step` records
 ## Mash Step Wrapper
 
 A `::mash` record wrapped in a `:mash` map
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -190,6 +231,7 @@ A record representing a step within the mashing process.
 
 A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:decoction-amt`
 - Clojure Type: String
 - Example: `"7.5 liters"`
@@ -198,6 +240,7 @@ A non-empty string denoting a display value for the calculated volume of mash to
 
 A non-empty string describing the mash step.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:description`
 - Clojure Type: String
 - Example: `"Stir your grain bag carefully at 140F."`
@@ -206,6 +249,7 @@ A non-empty string describing the mash step.
 
 A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-infuse-amt`
 - Clojure Type: String
 - Example: `"2.2L"`
@@ -214,6 +258,7 @@ A non-empty string denoting a display value for the volume of infused liquid for
 
 A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-step-temp`
 - Clojure Type: String
 - Example: `"150F"`
@@ -222,6 +267,8 @@ A non-empty string denoting a display value for the temperature of an arbitrary 
 
 A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:end-temp`
 - Clojure Type: Double
 - Example: `80.0`
@@ -230,6 +277,8 @@ A non-negative IEEE-754 floating point number representing the temperature of th
 
 A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:infuse-amount`
 - Clojure Type: Double
 - Example: `5.8`
@@ -238,6 +287,7 @@ A non-negative IEEE-754 floating point number representing the volume of water i
 
 A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:infuse-temp`
 - Clojure Type: String
 - Example: `"150F"`
@@ -246,6 +296,7 @@ A non-empty string denoting a display value for the temperature of an infusion s
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -254,6 +305,8 @@ A non-empty string representing the name of the ingredient.
 
 A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:ramp-time`
 - Clojure Type: Double
 - Example: `45.0`
@@ -262,6 +315,8 @@ A non-negative IEEE-754 floating point number representing the time in minutes t
 
 A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:step-temp`
 - Clojure Type: Double
 - Example: `80.0`
@@ -270,6 +325,8 @@ A non-negative IEEE-754 floating point number representing the temperature of th
 
 A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:step-time`
 - Clojure Type: Double
 - Example: `45.0`
@@ -283,6 +340,7 @@ Must be one of: "Decoction", "Temperature", "Infusion"
 - Infusion: A mash step where fermentable ingredients steep in water at a specific temperature.
 - Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"Temperature"`
@@ -291,6 +349,7 @@ Must be one of: "Decoction", "Temperature", "Infusion"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`
@@ -299,6 +358,7 @@ An integer representing the version of the BeerXML standard implemented in a giv
 
 A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:water-grain-ratio`
 - Clojure Type: String
 - Example: `"1.5qt/lb"`

--- a/doc/specs/miscs.md
+++ b/doc/specs/miscs.md
@@ -4,6 +4,8 @@
 
 A `::miscs` record.
 
+- BeerXML Type: `Record Set`
+
 ### Wrapped Record
 
 - [Miscellaneous Ingredients](#miscellaneous-ingredients)
@@ -19,6 +21,8 @@ A vector of valid `::misc` records.
 ## Miscellaneous Ingredient Wrapper
 
 A `::misc` record wrapped in a `:misc` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -48,8 +52,12 @@ A record representing a miscellaneous ingredient in a beer recipe.
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient.
+A value representing the amount of a particular ingredient.
+When measuring weight, this is in kilograms.
+When measuring volume, this is in liters.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Kilogram, Liter
 - Clojure Key Name: `:amount`
 - Clojure Type: Double
 - Example: `12.5`
@@ -59,6 +67,7 @@ A ::kilogram value representing the amount of a particular ingredient.
 A boolean representing if the amount of the substance is measured in kilograms.
 When absent, assume false and that the amount of substance is measured in liters.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:amount-is-weight`
 - Clojure Type: Boolean
 - Example: `false`
@@ -67,6 +76,7 @@ When absent, assume false and that the amount of substance is measured in liters
 
 A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-amount`
 - Clojure Type: String
 - Example: `"100 g"`
@@ -75,6 +85,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-time`
 - Clojure Type: String
 - Example: `"10 days"`
@@ -83,6 +94,7 @@ A non-empty string denoting a display value for an amount of time formatted for 
 
 A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:inventory`
 - Clojure Type: String
 - Example: `"100 lbs"`
@@ -91,6 +103,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -99,17 +112,20 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Time
 
-A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the :use field.
+A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the `:use` field.
 For "Boil" this is the boil time.
 For "Mash" this is the mash time.
 For "Primary", "Secondary", and "Bottling" this is the amount of time the ingredient spent in that state.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:time`
 - Clojure Type: Double
 - Example: `15.0`
@@ -126,6 +142,7 @@ Must be one of: "Flavor", "Spice", "Water agent", "Fining", "Other", "Herb"
 - Spice: A spice, such as cinnamon or ginger.
 - Water Agent: A water agent, such as campden tablet.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"Spice"`
@@ -141,6 +158,7 @@ Must be one of: "Mash", "Boil", "Bottling", "Secondary", "Primary"
 - Secondary: The ingredient is added to the secondary fermentation.
 - Bottling: The ingredient is added during the bottling process.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:use`
 - Clojure Type: String
 - Example: `"Mash"`
@@ -149,6 +167,7 @@ Must be one of: "Mash", "Boil", "Bottling", "Secondary", "Primary"
 
 A non-empty string denoting what the ingredient is used for.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:use-for`
 - Clojure Type: String
 - Example: `"Used to impart a mild, zesty flavor"`
@@ -157,6 +176,7 @@ A non-empty string denoting what the ingredient is used for.
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/miscs.md
+++ b/doc/specs/miscs.md
@@ -48,10 +48,10 @@ A record representing a miscellaneous ingredient in a beer recipe.
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient
+A ::kilogram value representing the amount of a particular ingredient.
 
-- Key Name: `:amount`
-- Type: Double
+- Clojure Key Name: `:amount`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Amount Is Weight
@@ -59,48 +59,48 @@ A ::kilogram value representing the amount of a particular ingredient
 A boolean representing if the amount of the substance is measured in kilograms.
 When absent, assume false and that the amount of substance is measured in liters.
 
-- Key Name: `:amount-is-weight`
-- Type: Boolean
+- Clojure Key Name: `:amount-is-weight`
+- Clojure Type: Boolean
 - Example: `false`
 
 ## Display Amount
 
-A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
-- Key Name: `:display-amount`
-- Type: String
+- Clojure Key Name: `:display-amount`
+- Clojure Type: String
 - Example: `"100 g"`
 
 ## Display Time
 
-A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units
+A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units.
 
-- Key Name: `:display-time`
-- Type: String
+- Clojure Key Name: `:display-time`
+- Clojure Type: String
 - Example: `"10 days"`
 
 ## Inventory
 
-A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
-- Key Name: `:inventory`
-- Type: String
+- Clojure Key Name: `:inventory`
+- Clojure Type: String
 - Example: `"100 lbs"`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Time
@@ -110,14 +110,14 @@ For "Boil" this is the boil time.
 For "Mash" this is the mash time.
 For "Primary", "Secondary", and "Bottling" this is the amount of time the ingredient spent in that state.
 
-- Key Name: `:time`
-- Type: Double
+- Clojure Key Name: `:time`
+- Clojure Type: Double
 - Example: `15.0`
 
 ## Type
 
-A case-insensitive string representing the type of the miscellaneous item added to the beer.
-Must be one of: "Herb", "Spice", "Flavor", "Water agent", "Other", "Fining"
+A case-sensitive string representing the type of the miscellaneous item added to the beer.
+Must be one of: "Flavor", "Spice", "Water agent", "Fining", "Other", "Herb"
 
 - Fining: A fining agent, such as isinglass.
 - Flavor: A flavoring, such as orange peel or a flavor concentrate.
@@ -126,14 +126,14 @@ Must be one of: "Herb", "Spice", "Flavor", "Water agent", "Other", "Fining"
 - Spice: A spice, such as cinnamon or ginger.
 - Water Agent: A water agent, such as campden tablet.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"Spice"`
 
 ## Use
 
-A case-insensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer.
-Must be one of: "Boil", "Secondary", "Primary", "Mash", "Bottling"
+A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer.
+Must be one of: "Mash", "Boil", "Bottling", "Secondary", "Primary"
 
 - Boil: The ingredient is added to the boil.
 - Mash: The ingredient is added to the mash.
@@ -141,22 +141,22 @@ Must be one of: "Boil", "Secondary", "Primary", "Mash", "Bottling"
 - Secondary: The ingredient is added to the secondary fermentation.
 - Bottling: The ingredient is added during the bottling process.
 
-- Key Name: `:use`
-- Type: String
+- Clojure Key Name: `:use`
+- Clojure Type: String
 - Example: `"Mash"`
 
 ## Use For
 
 A non-empty string denoting what the ingredient is used for.
 
-- Key Name: `:use-for`
-- Type: String
+- Clojure Key Name: `:use-for`
+- Clojure Type: String
 - Example: `"Used to impart a mild, zesty flavor"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/miscs.md
+++ b/doc/specs/miscs.md
@@ -1,0 +1,162 @@
+# Misc Records
+
+## Miscellaneous Ingredients Wrapper
+
+A `::miscs` record.
+
+### Wrapped Record
+
+- [Miscellaneous Ingredients](#miscellaneous-ingredients)
+
+## Miscellaneous Ingredients
+
+A vector of valid `::misc` records.
+
+### Collection Type
+
+- [Miscellaneous Ingredient Wrapper](#miscellaneous-ingredient-wrapper)
+
+## Miscellaneous Ingredient Wrapper
+
+A `::misc` record wrapped in a `:misc` map.
+
+### Wrapped Record
+
+- [Miscellaneous Ingredient](#miscellaneous-ingredient)
+
+## Miscellaneous Ingredient
+
+A record representing a miscellaneous ingredient in a beer recipe.
+
+### Required Keys
+
+- [Amount](#amount)
+- [Name](#name)
+- [Time](#time)
+- [Type](#type)
+- [Use](#use)
+- [Version](#version)
+
+### Optional Keys
+
+- [Amount Is Weight](#amount-is-weight)
+- [Display Amount](#display-amount)
+- [Display Time](#display-time)
+- [Inventory](#inventory)
+- [Notes](#notes)
+- [Use For](#use-for)
+
+## Amount
+
+A ::kilogram value representing the amount of a particular ingredient
+
+- Key Name: `:amount`
+- Type: Double
+- Example: `12.5`
+
+## Amount Is Weight
+
+A boolean representing if the amount of the substance is measured in kilograms.
+When absent, assume false and that the amount of substance is measured in liters.
+
+- Key Name: `:amount-is-weight`
+- Type: Boolean
+- Example: `false`
+
+## Display Amount
+
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+
+- Key Name: `:display-amount`
+- Type: String
+- Example: `"100 g"`
+
+## Display Time
+
+A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units
+
+- Key Name: `:display-time`
+- Type: String
+- Example: `"10 days"`
+
+## Inventory
+
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+
+- Key Name: `:inventory`
+- Type: String
+- Example: `"100 lbs"`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Time
+
+A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the :use field.
+For "Boil" this is the boil time.
+For "Mash" this is the mash time.
+For "Primary", "Secondary", and "Bottling" this is the amount of time the ingredient spent in that state.
+
+- Key Name: `:time`
+- Type: Double
+- Example: `15.0`
+
+## Type
+
+A case-insensitive string representing the type of the miscellaneous item added to the beer.
+Must be one of: "Herb", "Spice", "Flavor", "Water agent", "Other", "Fining"
+
+- Fining: A fining agent, such as isinglass.
+- Flavor: A flavoring, such as orange peel or a flavor concentrate.
+- Herb: An herb, such as mint.
+- Other: Any other type of miscellaneous ingredient.
+- Spice: A spice, such as cinnamon or ginger.
+- Water Agent: A water agent, such as campden tablet.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"Spice"`
+
+## Use
+
+A case-insensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer.
+Must be one of: "Boil", "Secondary", "Primary", "Mash", "Bottling"
+
+- Boil: The ingredient is added to the boil.
+- Mash: The ingredient is added to the mash.
+- Primary: The ingredient is added to the primary fermentation.
+- Secondary: The ingredient is added to the secondary fermentation.
+- Bottling: The ingredient is added during the bottling process.
+
+- Key Name: `:use`
+- Type: String
+- Example: `"Mash"`
+
+## Use For
+
+A non-empty string denoting what the ingredient is used for.
+
+- Key Name: `:use-for`
+- Type: String
+- Example: `"Used to impart a mild, zesty flavor"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/recipes.md
+++ b/doc/specs/recipes.md
@@ -95,104 +95,104 @@ A record representing a beer recipe.
 
 A non-negative IEEE-754 floating point number representing the actual ABV for the recipe.
 
-- Key Name: `:abv`
-- Type: Double
+- Clojure Key Name: `:abv`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Actual Efficiency
 
 A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities.
 
-- Key Name: `:actual-efficiency`
-- Type: Double
+- Clojure Key Name: `:actual-efficiency`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Age
 
 A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer.
 
-- Key Name: `:age`
-- Type: Double
+- Clojure Key Name: `:age`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Aging Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging.
 
-- Key Name: `:age-temp`
-- Type: Double
+- Clojure Key Name: `:age-temp`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Assistant Brewer
 
 A non-empty string denoting the name of the assistant brewer.
 
-- Key Name: `:asst-brewer`
-- Type: String
+- Clojure Key Name: `:asst-brewer`
+- Clojure Type: String
 - Example: `"Dariusz R. Jakubowski"`
 
 ## Batch Size
 
 A non-negative IEEE-754 floating point number representing the target final volume of recipe.
 
-- Key Name: `:batch-size`
-- Type: Double
+- Clojure Key Name: `:batch-size`
+- Clojure Type: Double
 - Example: `5.8`
 
 ## Boil Size
 
 A non-negative IEEE-754 floating point number representing the starting volume of the wort.
 
-- Key Name: `:boil-size`
-- Type: Double
+- Clojure Key Name: `:boil-size`
+- Clojure Type: Double
 - Example: `7.5`
 
 ## Boil Time
 
 A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort.
 
-- Key Name: `:boil-time`
-- Type: Double
+- Clojure Key Name: `:boil-time`
+- Clojure Type: Double
 - Example: `45.0`
 
 ## Brewer
 
 A non-empty string denoting the name of the brewer.
 
-- Key Name: `:brewer`
-- Type: String
+- Clojure Key Name: `:brewer`
+- Clojure Type: String
 - Example: `"Nick A. Nichols"`
 
 ## Calories
 
 A non-empty string describing the number of dietary calories per serving of this recipe.
 
-- Key Name: `:calories`
-- Type: String
+- Clojure Key Name: `:calories`
+- Clojure Type: String
 - Example: `"180 Cal / pint"`
 
 ## Carbonation
 
 An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2.
 
-- Key Name: `:carbonation`
-- Type: Double
+- Clojure Key Name: `:carbonation`
+- Clojure Type: Double
 - Example: `1.5`
 
 ## Carbonation Temp
 
 An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation.
 
-- Key Name: `:carbonation-temp`
-- Type: Double
+- Clojure Key Name: `:carbonation-temp`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Carbonation Used
 
 A non-empty string denoting a display value for the carbonation measures used formatted for display in arbitrary units.
 
-- Key Name: `:carbonation-used`
-- Type: String
+- Clojure Key Name: `:carbonation-used`
+- Clojure Type: String
 - Example: `"Kegged at 1.36 atmospheres"`
 
 ## Date
@@ -200,136 +200,136 @@ A non-empty string denoting a display value for the carbonation measures used fo
 A non-empty string denoting the display date the recipe was created on.
 Intentionally implemented as a string type to match BeerXML spec.
 
-- Key Name: `:date`
-- Type: String
+- Clojure Key Name: `:date`
+- Clojure Type: String
 - Example: `"2020/05/06"`
 
 ## Display Aging Temperature
 
 A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units.
 
-- Key Name: `:display-age-temp`
-- Type: String
+- Clojure Key Name: `:display-age-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Display Batch Size
 
 A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units.
 
-- Key Name: `:display-batch-size`
-- Type: String
+- Clojure Key Name: `:display-batch-size`
+- Clojure Type: String
 - Example: `"4.5 gallons"`
 
 ## Display Boil Size
 
 A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units.
 
-- Key Name: `:display-boil-size`
-- Type: String
+- Clojure Key Name: `:display-boil-size`
+- Clojure Type: String
 - Example: `"5.0 gallons"`
 
 ## Display Carbonation Temperature
 
 A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units.
 
-- Key Name: `:display-carb-temp`
-- Type: String
+- Clojure Key Name: `:display-carb-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Display Final Gravity
 
 A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-fg`
-- Type: String
+- Clojure Key Name: `:display-fg`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Display Original Gravity
 
 A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-og`
-- Type: String
+- Clojure Key Name: `:display-og`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Display Primary Temperature
 
 A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units.
 
-- Key Name: `:display-primary-temp`
-- Type: String
+- Clojure Key Name: `:display-primary-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Display Secondary Temperature
 
 A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units.
 
-- Key Name: `:display-secondary-temp`
-- Type: String
+- Clojure Key Name: `:display-secondary-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Display Tertiary Temperature
 
 A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units.
 
-- Key Name: `:display-tertiary-temp`
-- Type: String
+- Clojure Key Name: `:display-tertiary-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Efficiency
 
 A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer.
 
-- Key Name: `:efficiency`
-- Type: Double
+- Clojure Key Name: `:efficiency`
+- Clojure Type: Double
 - Example: `85.6`
 
 ## Estimated ABV
 
 A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe.
 
-- Key Name: `:est-abv`
-- Type: Double
+- Clojure Key Name: `:est-abv`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Estimated Color
 
 A non-empty string describing the calculated color formatted for display in arbitrary units.
 
-- Key Name: `:est-color`
-- Type: String
+- Clojure Key Name: `:est-color`
+- Clojure Type: String
 - Example: `"30SRM"`
 
 ## Estimated Final Gravity
 
 A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units.
 
-- Key Name: `:est-fg`
-- Type: String
+- Clojure Key Name: `:est-fg`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Estimated Original Gravity
 
 A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units.
 
-- Key Name: `:est-og`
-- Type: String
+- Clojure Key Name: `:est-og`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Fermentation Stages
 
 An integer representing the number of fermentation stages in the recipe.
 
-- Key Name: `:fermentation-stages`
-- Type: Long
+- Clojure Key Name: `:fermentation-stages`
+- Clojure Type: Long
 - Example: `2`
 
 ## Final Gravity
 
 A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe.
 
-- Key Name: `:fg`
-- Type: Double
+- Clojure Key Name: `:fg`
+- Clojure Type: Double
 - Example: `1.048`
 
 ## Forced Carbonation
@@ -337,160 +337,160 @@ A non-negative IEEE-754 floating point number representing the post-fermentation
 A boolean representing if this batch was force carbonated with CO2 pressure.
 When absent, assume false.
 
-- Key Name: `:forced-carbonation`
-- Type: Spec
+- Clojure Key Name: `:forced-carbonation`
+- Clojure Type: Spec
 - Example: `false`
 
 ## International Bitterness Units
 
 A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe.
 
-- Key Name: `:ibu`
-- Type: Double
+- Clojure Key Name: `:ibu`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Ibu Method
 
-A case-insensitive string representing the method of calculation used derive the IBUs.
-Must be one of: "Garetz", "Rager", "Tinseth"
+A case-sensitive string representing the method of calculation used derive the IBUs.
+Must be one of: "Tinseth", "Rager", "Garetz"
 
 - Garetz: The Garetz method of IBU calculation.
 - Rager: The Rager method of IBU calculation.
 - Tinseth: The Tinseth method of IBU calculation.
 
-- Key Name: `:ibu-method`
-- Type: String
+- Clojure Key Name: `:ibu-method`
+- Clojure Type: String
 - Example: `"Garetz"`
 
 ## Keg Priming Factor
 
 An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers.
 
-- Key Name: `:keg-priming-factor`
-- Type: Double
+- Clojure Key Name: `:keg-priming-factor`
+- Clojure Type: Double
 - Example: `1.5`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Original Gravity
 
 A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe.
 
-- Key Name: `:og`
-- Type: Double
+- Clojure Key Name: `:og`
+- Clojure Type: Double
 - Example: `1.06`
 
 ## Primary Age
 
 A positive IEEE-754 floating point number representing the number of days spent in primary fermentation.
 
-- Key Name: `:primary-age`
-- Type: Double
+- Clojure Key Name: `:primary-age`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Primary Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation.
 
-- Key Name: `:primary-temp`
-- Type: Double
+- Clojure Key Name: `:primary-temp`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Priming Sugar Equivalent
 
 An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar.
 
-- Key Name: `:priming-sugar-equiv`
-- Type: Double
+- Clojure Key Name: `:priming-sugar-equiv`
+- Clojure Type: Double
 - Example: `1.5`
 
 ## Priming Sugar Name
 
 A non-empty string denoting the name of the priming agent used to carbonate the beer.
 
-- Key Name: `:priming-sugar-name`
-- Type: String
+- Clojure Key Name: `:priming-sugar-name`
+- Clojure Type: String
 - Example: `"Corn Sugar"`
 
 ## Secondary Age
 
 A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation.
 
-- Key Name: `:secondary-age`
-- Type: Double
+- Clojure Key Name: `:secondary-age`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Secondary Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation.
 
-- Key Name: `:secondary-temp`
-- Type: Double
+- Clojure Key Name: `:secondary-temp`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Taste Notes
 
 A non-empty string denoting any tasting notes.
 
-- Key Name: `:taste-notes`
-- Type: String
+- Clojure Key Name: `:taste-notes`
+- Clojure Type: String
 - Example: `"A nice, full body and intense mouthfeel"`
 
 ## Taste Rating
 
 An IEEE-754 floating point number representing the tasting score of the beer.
 
-- Key Name: `:taste-rating`
-- Type: Double
+- Clojure Key Name: `:taste-rating`
+- Clojure Type: Double
 - Example: `100.0`
 
 ## Tertiary Age
 
 A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation.
 
-- Key Name: `:tertiary-age`
-- Type: Double
+- Clojure Key Name: `:tertiary-age`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Tertiary Temperature
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation.
 
-- Key Name: `:tertiary-temp`
-- Type: Double
+- Clojure Key Name: `:tertiary-temp`
+- Clojure Type: Double
 - Example: `12.0`
 
 ## Type
 
-A case-insensitive string representing the type of recipe.
-Must be one of: "Extract", "All grain", "Partial mash"
+A case-sensitive string representing the type of recipe.
+Must be one of: "Partial mash", "All grain", "Extract"
 
 - All Grain: A recipe that uses only malted grains.
 - Partial Mash: A recipe that uses a combination of malted grains and malt extract.
 - Extract: A recipe that uses only malt extract.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"All Grain"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/recipes.md
+++ b/doc/specs/recipes.md
@@ -1,0 +1,496 @@
+# Recipe Records
+
+## Recipes Wrapper
+
+A `::recipes-wrapper` record.
+
+### Wrapped Record
+
+- [Recipes](#recipes)
+
+## Recipes
+
+A vector of valid `::recipe` records.
+
+### Collection Type
+
+- [Recipe Wrapper](#recipe-wrapper)
+
+## Recipe Wrapper
+
+A `::recipe` record wrapped in a `:recipes` map.
+
+### Wrapped Record
+
+- [Recipe](#recipe)
+
+## Recipe
+
+A record representing a beer recipe.
+
+### Required Keys
+
+- [Batch Size](#batch-size)
+- [Boil Size](#boil-size)
+- [Boil Time](#boil-time)
+- [Brewer](#brewer)
+- [Fermentables](#fermentables)
+- [Hops](#hops)
+- [Mash](#mash)
+- [Miscellaneous Ingredients](#miscellaneous-ingredients)
+- [Name](#name)
+- [Style](#style)
+- [Type](#type)
+- [Version](#version)
+- [Waters](#waters)
+- [Yeasts](#yeasts)
+
+### Optional Keys
+
+- [Abv](#abv)
+- [Actual Efficiency](#actual-efficiency)
+- [Age](#age)
+- [Aging Temperature](#aging-temperature)
+- [Assistant Brewer](#assistant-brewer)
+- [Calories](#calories)
+- [Carbonation](#carbonation)
+- [Carbonation Temp](#carbonation-temp)
+- [Carbonation Used](#carbonation-used)
+- [Date](#date)
+- [Display Aging Temperature](#display-aging-temperature)
+- [Display Batch Size](#display-batch-size)
+- [Display Boil Size](#display-boil-size)
+- [Display Carbonation Temperature](#display-carbonation-temperature)
+- [Display Final Gravity](#display-final-gravity)
+- [Display Original Gravity](#display-original-gravity)
+- [Display Primary Temperature](#display-primary-temperature)
+- [Display Secondary Temperature](#display-secondary-temperature)
+- [Display Tertiary Temperature](#display-tertiary-temperature)
+- [Efficiency](#efficiency)
+- [Equipment](#equipment)
+- [Estimated ABV](#estimated-abv)
+- [Estimated Color](#estimated-color)
+- [Estimated Final Gravity](#estimated-final-gravity)
+- [Estimated Original Gravity](#estimated-original-gravity)
+- [Fermentation Stages](#fermentation-stages)
+- [Final Gravity](#final-gravity)
+- [Forced Carbonation](#forced-carbonation)
+- [International Bitterness Units](#international-bitterness-units)
+- [Ibu Method](#ibu-method)
+- [Keg Priming Factor](#keg-priming-factor)
+- [Notes](#notes)
+- [Original Gravity](#original-gravity)
+- [Primary Age](#primary-age)
+- [Primary Temperature](#primary-temperature)
+- [Priming Sugar Equivalent](#priming-sugar-equivalent)
+- [Priming Sugar Name](#priming-sugar-name)
+- [Secondary Age](#secondary-age)
+- [Secondary Temperature](#secondary-temperature)
+- [Taste Notes](#taste-notes)
+- [Taste Rating](#taste-rating)
+- [Tertiary Age](#tertiary-age)
+- [Tertiary Temperature](#tertiary-temperature)
+
+## Abv
+
+A non-negative IEEE-754 floating point number representing the actual ABV for the recipe.
+
+- Key Name: `:abv`
+- Type: Double
+- Example: `40.0`
+
+## Actual Efficiency
+
+A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities.
+
+- Key Name: `:actual-efficiency`
+- Type: Double
+- Example: `40.0`
+
+## Age
+
+A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer.
+
+- Key Name: `:age`
+- Type: Double
+- Example: `12.0`
+
+## Aging Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging.
+
+- Key Name: `:age-temp`
+- Type: Double
+- Example: `12.0`
+
+## Assistant Brewer
+
+A non-empty string denoting the name of the assistant brewer.
+
+- Key Name: `:asst-brewer`
+- Type: String
+- Example: `"Dariusz R. Jakubowski"`
+
+## Batch Size
+
+A non-negative IEEE-754 floating point number representing the target final volume of recipe.
+
+- Key Name: `:batch-size`
+- Type: Double
+- Example: `5.8`
+
+## Boil Size
+
+A non-negative IEEE-754 floating point number representing the starting volume of the wort.
+
+- Key Name: `:boil-size`
+- Type: Double
+- Example: `7.5`
+
+## Boil Time
+
+A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort.
+
+- Key Name: `:boil-time`
+- Type: Double
+- Example: `45.0`
+
+## Brewer
+
+A non-empty string denoting the name of the brewer.
+
+- Key Name: `:brewer`
+- Type: String
+- Example: `"Nick A. Nichols"`
+
+## Calories
+
+A non-empty string describing the number of dietary calories per serving of this recipe.
+
+- Key Name: `:calories`
+- Type: String
+- Example: `"180 Cal / pint"`
+
+## Carbonation
+
+An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2.
+
+- Key Name: `:carbonation`
+- Type: Double
+- Example: `1.5`
+
+## Carbonation Temp
+
+An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation.
+
+- Key Name: `:carbonation-temp`
+- Type: Double
+- Example: `12.0`
+
+## Carbonation Used
+
+A non-empty string denoting a display value for the carbonation measures used formatted for display in arbitrary units.
+
+- Key Name: `:carbonation-used`
+- Type: String
+- Example: `"Kegged at 1.36 atmospheres"`
+
+## Date
+
+A non-empty string denoting the display date the recipe was created on.
+Intentionally implemented as a string type to match BeerXML spec.
+
+- Key Name: `:date`
+- Type: String
+- Example: `"2020/05/06"`
+
+## Display Aging Temperature
+
+A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units.
+
+- Key Name: `:display-age-temp`
+- Type: String
+- Example: `"68F"`
+
+## Display Batch Size
+
+A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units.
+
+- Key Name: `:display-batch-size`
+- Type: String
+- Example: `"4.5 gallons"`
+
+## Display Boil Size
+
+A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units.
+
+- Key Name: `:display-boil-size`
+- Type: String
+- Example: `"5.0 gallons"`
+
+## Display Carbonation Temperature
+
+A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units.
+
+- Key Name: `:display-carb-temp`
+- Type: String
+- Example: `"68F"`
+
+## Display Final Gravity
+
+A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-fg`
+- Type: String
+- Example: `"1.050sg"`
+
+## Display Original Gravity
+
+A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-og`
+- Type: String
+- Example: `"1.050sg"`
+
+## Display Primary Temperature
+
+A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units.
+
+- Key Name: `:display-primary-temp`
+- Type: String
+- Example: `"68F"`
+
+## Display Secondary Temperature
+
+A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units.
+
+- Key Name: `:display-secondary-temp`
+- Type: String
+- Example: `"68F"`
+
+## Display Tertiary Temperature
+
+A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units.
+
+- Key Name: `:display-tertiary-temp`
+- Type: String
+- Example: `"68F"`
+
+## Efficiency
+
+A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer.
+
+- Key Name: `:efficiency`
+- Type: Double
+- Example: `85.6`
+
+## Estimated ABV
+
+A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe.
+
+- Key Name: `:est-abv`
+- Type: Double
+- Example: `40.0`
+
+## Estimated Color
+
+A non-empty string describing the calculated color formatted for display in arbitrary units.
+
+- Key Name: `:est-color`
+- Type: String
+- Example: `"30SRM"`
+
+## Estimated Final Gravity
+
+A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units.
+
+- Key Name: `:est-fg`
+- Type: String
+- Example: `"1.050sg"`
+
+## Estimated Original Gravity
+
+A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units.
+
+- Key Name: `:est-og`
+- Type: String
+- Example: `"1.050sg"`
+
+## Fermentation Stages
+
+An integer representing the number of fermentation stages in the recipe.
+
+- Key Name: `:fermentation-stages`
+- Type: Long
+- Example: `2`
+
+## Final Gravity
+
+A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe.
+
+- Key Name: `:fg`
+- Type: Double
+- Example: `1.048`
+
+## Forced Carbonation
+
+A boolean representing if this batch was force carbonated with CO2 pressure.
+When absent, assume false.
+
+- Key Name: `:forced-carbonation`
+- Type: Spec
+- Example: `false`
+
+## International Bitterness Units
+
+A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe.
+
+- Key Name: `:ibu`
+- Type: Double
+- Example: `40.0`
+
+## Ibu Method
+
+A case-insensitive string representing the method of calculation used derive the IBUs.
+Must be one of: "Garetz", "Rager", "Tinseth"
+
+- Garetz: The Garetz method of IBU calculation.
+- Rager: The Rager method of IBU calculation.
+- Tinseth: The Tinseth method of IBU calculation.
+
+- Key Name: `:ibu-method`
+- Type: String
+- Example: `"Garetz"`
+
+## Keg Priming Factor
+
+An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers.
+
+- Key Name: `:keg-priming-factor`
+- Type: Double
+- Example: `1.5`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Original Gravity
+
+A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe.
+
+- Key Name: `:og`
+- Type: Double
+- Example: `1.06`
+
+## Primary Age
+
+A positive IEEE-754 floating point number representing the number of days spent in primary fermentation.
+
+- Key Name: `:primary-age`
+- Type: Double
+- Example: `12.0`
+
+## Primary Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation.
+
+- Key Name: `:primary-temp`
+- Type: Double
+- Example: `12.0`
+
+## Priming Sugar Equivalent
+
+An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar.
+
+- Key Name: `:priming-sugar-equiv`
+- Type: Double
+- Example: `1.5`
+
+## Priming Sugar Name
+
+A non-empty string denoting the name of the priming agent used to carbonate the beer.
+
+- Key Name: `:priming-sugar-name`
+- Type: String
+- Example: `"Corn Sugar"`
+
+## Secondary Age
+
+A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation.
+
+- Key Name: `:secondary-age`
+- Type: Double
+- Example: `12.0`
+
+## Secondary Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation.
+
+- Key Name: `:secondary-temp`
+- Type: Double
+- Example: `12.0`
+
+## Taste Notes
+
+A non-empty string denoting any tasting notes.
+
+- Key Name: `:taste-notes`
+- Type: String
+- Example: `"A nice, full body and intense mouthfeel"`
+
+## Taste Rating
+
+An IEEE-754 floating point number representing the tasting score of the beer.
+
+- Key Name: `:taste-rating`
+- Type: Double
+- Example: `100.0`
+
+## Tertiary Age
+
+A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation.
+
+- Key Name: `:tertiary-age`
+- Type: Double
+- Example: `12.0`
+
+## Tertiary Temperature
+
+A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation.
+
+- Key Name: `:tertiary-temp`
+- Type: Double
+- Example: `12.0`
+
+## Type
+
+A case-insensitive string representing the type of recipe.
+Must be one of: "Extract", "All grain", "Partial mash"
+
+- All Grain: A recipe that uses only malted grains.
+- Partial Mash: A recipe that uses a combination of malted grains and malt extract.
+- Extract: A recipe that uses only malt extract.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"All Grain"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/recipes.md
+++ b/doc/specs/recipes.md
@@ -4,6 +4,8 @@
 
 A `::recipes-wrapper` record.
 
+- BeerXML Type: `Record Set`
+
 ### Wrapped Record
 
 - [Recipes](#recipes)
@@ -19,6 +21,8 @@ A vector of valid `::recipe` records.
 ## Recipe Wrapper
 
 A `::recipe` record wrapped in a `:recipes` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -95,22 +99,27 @@ A record representing a beer recipe.
 
 A non-negative IEEE-754 floating point number representing the actual ABV for the recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: ABV
 - Clojure Key Name: `:abv`
 - Clojure Type: Double
-- Example: `40.0`
+- Example: `40.2`
 
 ## Actual Efficiency
 
 A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:actual-efficiency`
 - Clojure Type: Double
-- Example: `40.0`
+- Example: `40.3`
 
 ## Age
 
 A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Day
 - Clojure Key Name: `:age`
 - Clojure Type: Double
 - Example: `12.0`
@@ -119,6 +128,8 @@ A non-negative IEEE-754 floating point number representing the number of days to
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:age-temp`
 - Clojure Type: Double
 - Example: `12.0`
@@ -127,6 +138,7 @@ A non-negative IEEE-754 floating point number representing the temperature in de
 
 A non-empty string denoting the name of the assistant brewer.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:asst-brewer`
 - Clojure Type: String
 - Example: `"Dariusz R. Jakubowski"`
@@ -135,6 +147,8 @@ A non-empty string denoting the name of the assistant brewer.
 
 A non-negative IEEE-754 floating point number representing the target final volume of recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:batch-size`
 - Clojure Type: Double
 - Example: `5.8`
@@ -143,6 +157,8 @@ A non-negative IEEE-754 floating point number representing the target final volu
 
 A non-negative IEEE-754 floating point number representing the starting volume of the wort.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Liter
 - Clojure Key Name: `:boil-size`
 - Clojure Type: Double
 - Example: `7.5`
@@ -151,6 +167,8 @@ A non-negative IEEE-754 floating point number representing the starting volume o
 
 A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Minute
 - Clojure Key Name: `:boil-time`
 - Clojure Type: Double
 - Example: `45.0`
@@ -159,6 +177,7 @@ A non-negative IEEE-754 floating point number representing the time in minutes t
 
 A non-empty string denoting the name of the brewer.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:brewer`
 - Clojure Type: String
 - Example: `"Nick A. Nichols"`
@@ -167,6 +186,7 @@ A non-empty string denoting the name of the brewer.
 
 A non-empty string describing the number of dietary calories per serving of this recipe.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:calories`
 - Clojure Type: String
 - Example: `"180 Cal / pint"`
@@ -175,6 +195,8 @@ A non-empty string describing the number of dietary calories per serving of this
 
 An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Volumes of CO2
 - Clojure Key Name: `:carbonation`
 - Clojure Type: Double
 - Example: `1.5`
@@ -183,6 +205,8 @@ An IEEE-754 floating point number representing the carbonation for this recipe i
 
 An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:carbonation-temp`
 - Clojure Type: Double
 - Example: `12.0`
@@ -191,6 +215,7 @@ An IEEE-754 floating point number representing the temperature in degrees Celsiu
 
 A non-empty string denoting a display value for the carbonation measures used formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:carbonation-used`
 - Clojure Type: String
 - Example: `"Kegged at 1.36 atmospheres"`
@@ -200,6 +225,7 @@ A non-empty string denoting a display value for the carbonation measures used fo
 A non-empty string denoting the display date the recipe was created on.
 Intentionally implemented as a string type to match BeerXML spec.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:date`
 - Clojure Type: String
 - Example: `"2020/05/06"`
@@ -208,6 +234,7 @@ Intentionally implemented as a string type to match BeerXML spec.
 
 A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-age-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -216,6 +243,7 @@ A non-empty string denoting a display value for the temperature of the aging ste
 
 A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-batch-size`
 - Clojure Type: String
 - Example: `"4.5 gallons"`
@@ -224,6 +252,7 @@ A non-empty string denoting a display value for the pre-fermentation volume form
 
 A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-boil-size`
 - Clojure Type: String
 - Example: `"5.0 gallons"`
@@ -232,6 +261,7 @@ A non-empty string denoting a display value for the pre-boil volume formatted fo
 
 A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-carb-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -240,6 +270,7 @@ A non-empty string denoting a display value for the temperature of the bottling 
 
 A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-fg`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -248,6 +279,7 @@ A non-empty string denoting a display value for the post-fermentation gravity fo
 
 A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-og`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -256,6 +288,7 @@ A non-empty string denoting a display value for the pre-fermentation gravity for
 
 A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-primary-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -264,6 +297,7 @@ A non-empty string denoting a display value for the temperature of the primary f
 
 A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-secondary-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -272,6 +306,7 @@ A non-empty string denoting a display value for the temperature of the secondary
 
 A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-tertiary-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -280,6 +315,7 @@ A non-empty string denoting a display value for the temperature of the tertiary 
 
 A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:efficiency`
 - Clojure Type: Double
 - Example: `85.6`
@@ -288,14 +324,17 @@ A non-negative IEEE-754 floating point number representing the percent brewhouse
 
 A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: ABV
 - Clojure Key Name: `:est-abv`
 - Clojure Type: Double
-- Example: `40.0`
+- Example: `40.1`
 
 ## Estimated Color
 
 A non-empty string describing the calculated color formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:est-color`
 - Clojure Type: String
 - Example: `"30SRM"`
@@ -304,6 +343,7 @@ A non-empty string describing the calculated color formatted for display in arbi
 
 A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:est-fg`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -312,6 +352,7 @@ A non-empty string describing the calculated estimated final gravity formatted f
 
 A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:est-og`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -320,6 +361,7 @@ A non-empty string describing the calculated estimated original gravity formatte
 
 An integer representing the number of fermentation stages in the recipe.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:fermentation-stages`
 - Clojure Type: Long
 - Example: `2`
@@ -328,6 +370,8 @@ An integer representing the number of fermentation stages in the recipe.
 
 A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:fg`
 - Clojure Type: Double
 - Example: `1.048`
@@ -337,6 +381,7 @@ A non-negative IEEE-754 floating point number representing the post-fermentation
 A boolean representing if this batch was force carbonated with CO2 pressure.
 When absent, assume false.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:forced-carbonation`
 - Clojure Type: Spec
 - Example: `false`
@@ -345,6 +390,8 @@ When absent, assume false.
 
 A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: IBU
 - Clojure Key Name: `:ibu`
 - Clojure Type: Double
 - Example: `40.0`
@@ -358,6 +405,7 @@ Must be one of: "Tinseth", "Rager", "Garetz"
 - Rager: The Rager method of IBU calculation.
 - Tinseth: The Tinseth method of IBU calculation.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:ibu-method`
 - Clojure Type: String
 - Example: `"Garetz"`
@@ -366,6 +414,7 @@ Must be one of: "Tinseth", "Rager", "Garetz"
 
 An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:keg-priming-factor`
 - Clojure Type: Double
 - Example: `1.5`
@@ -374,6 +423,7 @@ An IEEE-754 floating point number representing the conversion factor of sugar ne
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -382,6 +432,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -390,6 +441,8 @@ A non-empty string representing any notes about the subject.
 
 A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:og`
 - Clojure Type: Double
 - Example: `1.06`
@@ -398,6 +451,8 @@ A non-negative IEEE-754 floating point number representing the pre-fermentation 
 
 A positive IEEE-754 floating point number representing the number of days spent in primary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Day
 - Clojure Key Name: `:primary-age`
 - Clojure Type: Double
 - Example: `12.0`
@@ -406,6 +461,8 @@ A positive IEEE-754 floating point number representing the number of days spent 
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:primary-temp`
 - Clojure Type: Double
 - Example: `12.0`
@@ -414,6 +471,7 @@ A non-negative IEEE-754 floating point number representing the temperature in de
 
 An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:priming-sugar-equiv`
 - Clojure Type: Double
 - Example: `1.5`
@@ -422,6 +480,7 @@ An IEEE-754 floating point number representing the conversion factor to an equiv
 
 A non-empty string denoting the name of the priming agent used to carbonate the beer.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:priming-sugar-name`
 - Clojure Type: String
 - Example: `"Corn Sugar"`
@@ -430,6 +489,8 @@ A non-empty string denoting the name of the priming agent used to carbonate the 
 
 A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Day
 - Clojure Key Name: `:secondary-age`
 - Clojure Type: Double
 - Example: `12.0`
@@ -438,6 +499,8 @@ A non-negative IEEE-754 floating point number representing the number of days sp
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:secondary-temp`
 - Clojure Type: Double
 - Example: `12.0`
@@ -446,6 +509,7 @@ A non-negative IEEE-754 floating point number representing the temperature in de
 
 A non-empty string denoting any tasting notes.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:taste-notes`
 - Clojure Type: String
 - Example: `"A nice, full body and intense mouthfeel"`
@@ -454,6 +518,7 @@ A non-empty string denoting any tasting notes.
 
 An IEEE-754 floating point number representing the tasting score of the beer.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:taste-rating`
 - Clojure Type: Double
 - Example: `100.0`
@@ -462,6 +527,8 @@ An IEEE-754 floating point number representing the tasting score of the beer.
 
 A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Day
 - Clojure Key Name: `:tertiary-age`
 - Clojure Type: Double
 - Example: `12.0`
@@ -470,6 +537,8 @@ A non-negative IEEE-754 floating point number representing the number of days sp
 
 A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:tertiary-temp`
 - Clojure Type: Double
 - Example: `12.0`
@@ -483,6 +552,7 @@ Must be one of: "Partial mash", "All grain", "Extract"
 - Partial Mash: A recipe that uses a combination of malted grains and malt extract.
 - Extract: A recipe that uses only malt extract.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"All Grain"`
@@ -491,6 +561,7 @@ Must be one of: "Partial mash", "All grain", "Extract"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/styles.md
+++ b/doc/specs/styles.md
@@ -2,7 +2,9 @@
 
 ## Styles Wrapper
 
-A `::styles-wrapper` record
+A `::styles-wrapper` record set.
+
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -10,7 +12,7 @@ A `::styles-wrapper` record
 
 ## Styles
 
-A vector of valid `::style` records
+A vector of valid `::style` records.
 
 ### Collection Type
 
@@ -18,7 +20,9 @@ A vector of valid `::style` records
 
 ## Style Wrapper
 
-A `::style` record wrapped in a `:style` map
+A `::style` record wrapped in a `:style` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -73,6 +77,8 @@ A record representing a beer style.
 
 A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style.
 
+- BeerXML Type: `Percentage`
+- BeerXML Unit: ABV
 - Clojure Key Name: `:abv-max`
 - Clojure Type: Double
 - Example: `0.04`
@@ -81,6 +87,8 @@ A non-negative IEEE-754 floating point number representing the maximum recommend
 
 A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style.
 
+- BeerXML Type: `Percentage`
+- BeerXML Unit: ABV
 - Clojure Key Name: `:abv-min`
 - Clojure Type: Double
 - Example: `0.032`
@@ -89,6 +97,7 @@ A non-negative IEEE-754 floating point number representing the minimum recommend
 
 A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:abv-range`
 - Clojure Type: String
 - Example: `"8.0-11.2%"`
@@ -97,6 +106,8 @@ A non-empty string denoting a display value for the range of ABV levels formatte
 
 A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2.
 
+- BeerXML Type: `Percentage`
+- BeerXML Unit: Volumes of CO2
 - Clojure Key Name: `:carb-max`
 - Clojure Type: Double
 - Example: `2.2`
@@ -105,6 +116,8 @@ A non-negative IEEE-754 floating point number representing the maximum carbonati
 
 A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2.
 
+- BeerXML Type: `Percentage`
+- BeerXML Unit: Volumes of CO2
 - Clojure Key Name: `:carb-min`
 - Clojure Type: Double
 - Example: `1.5`
@@ -113,6 +126,7 @@ A non-negative IEEE-754 floating point number representing the minimum carbonati
 
 A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:carb-range`
 - Clojure Type: String
 - Example: `"2.0-2.6 vols CO2"`
@@ -121,6 +135,7 @@ A non-empty string denoting a display value for the range of carbonation volumes
 
 A non-empty string denoting the category this style belongs to.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:category`
 - Clojure Type: String
 - Example: `"American Lagers"`
@@ -130,6 +145,7 @@ A non-empty string denoting the category this style belongs to.
 A non-empty string denoting the category number of this style.
 The category number is a string because it can be a letter followed by a number, e.g. 'A1' on some guides.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:category-number`
 - Clojure Type: String
 - Example: `"1"`
@@ -138,6 +154,8 @@ The category number is a string because it can be a letter followed by a number,
 
 A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: SRM
 - Clojure Key Name: `:color-max`
 - Clojure Type: Double
 - Example: `40.0`
@@ -146,6 +164,8 @@ A non-negative IEEE-754 floating point number representing the darkest color in 
 
 A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: SRM
 - Clojure Key Name: `:color-min`
 - Clojure Type: Double
 - Example: `32.0`
@@ -154,6 +174,7 @@ A non-negative IEEE-754 floating point number representing the lightest color in
 
 A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:color-range`
 - Clojure Type: String
 - Example: `"10 - 22 SRM"`
@@ -162,6 +183,7 @@ A non-empty string denoting a display value for the range of colors formatted fo
 
 A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-color-max`
 - Clojure Type: String
 - Example: `"40 SRM"`
@@ -170,6 +192,7 @@ A non-empty string denoting a display value for the maximum color formatted for 
 
 A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-color-min`
 - Clojure Type: String
 - Example: `"32SRM"`
@@ -178,6 +201,7 @@ A non-empty string denoting a display value for the minimum color formatted for 
 
 A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-fg-max`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -186,6 +210,7 @@ A non-empty string denoting a display value for the maximum final gravity format
 
 A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-fg-min`
 - Clojure Type: String
 - Example: `"1.036sg"`
@@ -194,6 +219,7 @@ A non-empty string denoting a display value for the minimum final gravity format
 
 A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-og-max`
 - Clojure Type: String
 - Example: `"1.050sg"`
@@ -202,6 +228,7 @@ A non-empty string denoting a display value for the maximum original gravity for
 
 A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-og-min`
 - Clojure Type: String
 - Example: `"1.036sg"`
@@ -210,6 +237,7 @@ A non-empty string denoting a display value for the minimum original gravity for
 
 A non-empty string denoting example beers of this style.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:examples`
 - Clojure Type: String
 - Example: `"Every overly citrus IPA on the market."`
@@ -218,6 +246,8 @@ A non-empty string denoting example beers of this style.
 
 A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:fg-max`
 - Clojure Type: Double
 - Example: `1.06`
@@ -226,6 +256,8 @@ A non-negative IEEE-754 floating point number representing the maximum post-ferm
 
 A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:fg-min`
 - Clojure Type: Double
 - Example: `1.048`
@@ -234,6 +266,7 @@ A non-negative IEEE-754 floating point number representing the minimum post-ferm
 
 A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:fg-range`
 - Clojure Type: String
 - Example: `"1.036sg-1.050sg"`
@@ -242,6 +275,8 @@ A non-empty string denoting a display value for the range of final gravities for
 
 A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: IBU
 - Clojure Key Name: `:ibu-max`
 - Clojure Type: Double
 - Example: `40.0`
@@ -250,6 +285,8 @@ A non-negative IEEE-754 floating point number representing the maximum bitternes
 
 A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: IBU
 - Clojure Key Name: `:ibu-min`
 - Clojure Type: Double
 - Example: `32.0`
@@ -258,6 +295,7 @@ A non-negative IEEE-754 floating point number representing the minimum bitternes
 
 A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:ibu-range`
 - Clojure Type: String
 - Example: `"10-20IBUs"`
@@ -266,6 +304,7 @@ A non-empty string denoting a display value for the range of International Bitte
 
 A non-empty string denoting the suggested ingredients for the style.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:ingredients`
 - Clojure Type: String
 - Example: `"water, barley, and hops."`
@@ -274,6 +313,7 @@ A non-empty string denoting the suggested ingredients for the style.
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -282,6 +322,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -290,6 +331,8 @@ A non-empty string representing any notes about the subject.
 
 A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:og-max`
 - Clojure Type: Double
 - Example: `1.06`
@@ -298,6 +341,8 @@ A non-negative IEEE-754 floating point number representing the maximum pre-ferme
 
 A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Specific Gravity
 - Clojure Key Name: `:og-min`
 - Clojure Type: Double
 - Example: `1.048`
@@ -306,6 +351,7 @@ A non-negative IEEE-754 floating point number representing the minimum pre-ferme
 
 A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:og-range`
 - Clojure Type: String
 - Example: `"1.036sg-1.050sg"`
@@ -314,6 +360,7 @@ A non-empty string denoting a display value for the range of original gravities 
 
 A non-empty string denoting the aroma and flavor profile of the style.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:profile`
 - Clojure Type: String
 - Example: `"Full-bodied and dark."`
@@ -322,6 +369,7 @@ A non-empty string denoting the aroma and flavor profile of the style.
 
 A non-empty string denoting the name of the style guide the style/category belongs to.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:style-guide`
 - Clojure Type: String
 - Example: `"BJCP"`
@@ -330,6 +378,7 @@ A non-empty string denoting the name of the style guide the style/category belon
 
 A non-empty string denoting the letter used to denote the style or sub-style.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:style-letter`
 - Clojure Type: String
 - Example: `"A"`
@@ -346,6 +395,7 @@ Must be one of: "Lager", "Cider", "Mixed", "Mead", "Wheat", "Ale"
 - Mixed: A beer style that blends two or more styles.
 - Wheat: A beer made with a large proportion of wheat malt.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"Lager"`
@@ -354,6 +404,7 @@ Must be one of: "Lager", "Cider", "Mixed", "Mead", "Wheat", "Ale"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/styles.md
+++ b/doc/specs/styles.md
@@ -1,0 +1,359 @@
+# Style Records
+
+## Styles Wrapper
+
+A `::styles-wrapper` record
+
+### Wrapped Record
+
+- [Styles](#styles)
+
+## Styles
+
+A vector of valid `::style` records
+
+### Collection Type
+
+- [Style Wrapper](#style-wrapper)
+
+## Style Wrapper
+
+A `::style` record wrapped in a `:style` map
+
+### Wrapped Record
+
+- [Style](#style)
+
+## Style
+
+A record representing a beer style.
+
+### Required Keys
+
+- [Category](#category)
+- [Category Number](#category-number)
+- [Color Max](#color-max)
+- [Color Min](#color-min)
+- [Maximum Final Gravity](#maximum-final-gravity)
+- [Minimum Final Gravity](#minimum-final-gravity)
+- [Maximum International Bittering Units](#maximum-international-bittering-units)
+- [Minimum International Bittering Units](#minimum-international-bittering-units)
+- [Name](#name)
+- [Maximum Original Gravity](#maximum-original-gravity)
+- [Minimum Original Gravity](#minimum-original-gravity)
+- [Style Guide](#style-guide)
+- [Style Letter](#style-letter)
+- [Type](#type)
+- [Version](#version)
+
+### Optional Keys
+
+- [Abv Max](#abv-max)
+- [Abv Min](#abv-min)
+- [Abv Range](#abv-range)
+- [Maximum Carbonation](#maximum-carbonation)
+- [Minimum Carbonation](#minimum-carbonation)
+- [Carbonation Range](#carbonation-range)
+- [Color Range](#color-range)
+- [Display Color Max](#display-color-max)
+- [Display Color Min](#display-color-min)
+- [Display Final Gravity Max](#display-final-gravity-max)
+- [Display Final Gravity Min](#display-final-gravity-min)
+- [Display Original Gravity Max](#display-original-gravity-max)
+- [Display Original Gravity Min](#display-original-gravity-min)
+- [Examples](#examples)
+- [Final Gravity Range](#final-gravity-range)
+- [International Bittering Units Range](#international-bittering-units-range)
+- [Ingredients](#ingredients)
+- [Notes](#notes)
+- [Original Gravity Range](#original-gravity-range)
+- [Profile](#profile)
+
+## Abv Max
+
+A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style.
+
+- Key Name: `:abv-max`
+- Type: Double
+- Example: `0.04`
+
+## Abv Min
+
+A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style.
+
+- Key Name: `:abv-min`
+- Type: Double
+- Example: `0.032`
+
+## Abv Range
+
+A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units.
+
+- Key Name: `:abv-range`
+- Type: String
+- Example: `"8.0-11.2%"`
+
+## Maximum Carbonation
+
+A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2.
+
+- Key Name: `:carb-max`
+- Type: Double
+- Example: `2.2`
+
+## Minimum Carbonation
+
+A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2.
+
+- Key Name: `:carb-min`
+- Type: Double
+- Example: `1.5`
+
+## Carbonation Range
+
+A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units.
+
+- Key Name: `:carb-range`
+- Type: String
+- Example: `"2.0-2.6 vols CO2"`
+
+## Category
+
+A non-empty string denoting the category this style belongs to.
+
+- Key Name: `:category`
+- Type: String
+- Example: `"American Lagers"`
+
+## Category Number
+
+A non-empty string denoting the category number of this style.
+The category number is a string because it can be a letter followed by a number, e.g. 'A1' on some guides.
+
+- Key Name: `:category-number`
+- Type: String
+- Example: `"1"`
+
+## Color Max
+
+A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style.
+
+- Key Name: `:color-max`
+- Type: Double
+- Example: `40.0`
+
+## Color Min
+
+A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style.
+
+- Key Name: `:color-min`
+- Type: Double
+- Example: `32.0`
+
+## Color Range
+
+A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units.
+
+- Key Name: `:color-range`
+- Type: String
+- Example: `"10 - 22 SRM"`
+
+## Display Color Max
+
+A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units.
+
+- Key Name: `:display-color-max`
+- Type: String
+- Example: `"40 SRM"`
+
+## Display Color Min
+
+A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units.
+
+- Key Name: `:display-color-min`
+- Type: String
+- Example: `"32SRM"`
+
+## Display Final Gravity Max
+
+A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-fg-max`
+- Type: String
+- Example: `"1.050sg"`
+
+## Display Final Gravity Min
+
+A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-fg-min`
+- Type: String
+- Example: `"1.036sg"`
+
+## Display Original Gravity Max
+
+A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-og-max`
+- Type: String
+- Example: `"1.050sg"`
+
+## Display Original Gravity Min
+
+A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units.
+
+- Key Name: `:display-og-min`
+- Type: String
+- Example: `"1.036sg"`
+
+## Examples
+
+A non-empty string denoting example beers of this style.
+
+- Key Name: `:examples`
+- Type: String
+- Example: `"Every overly citrus IPA on the market."`
+
+## Maximum Final Gravity
+
+A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style.
+
+- Key Name: `:fg-max`
+- Type: Double
+- Example: `1.06`
+
+## Minimum Final Gravity
+
+A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style.
+
+- Key Name: `:fg-min`
+- Type: Double
+- Example: `1.048`
+
+## Final Gravity Range
+
+A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units.
+
+- Key Name: `:fg-range`
+- Type: String
+- Example: `"1.036sg-1.050sg"`
+
+## Maximum International Bittering Units
+
+A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style.
+
+- Key Name: `:ibu-max`
+- Type: Double
+- Example: `40.0`
+
+## Minimum International Bittering Units
+
+A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style.
+
+- Key Name: `:ibu-min`
+- Type: Double
+- Example: `32.0`
+
+## International Bittering Units Range
+
+A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units.
+
+- Key Name: `:ibu-range`
+- Type: String
+- Example: `"10-20IBUs"`
+
+## Ingredients
+
+A non-empty string denoting the suggested ingredients for the style.
+
+- Key Name: `:ingredients`
+- Type: String
+- Example: `"water, barley, and hops."`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Maximum Original Gravity
+
+A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style.
+
+- Key Name: `:og-max`
+- Type: Double
+- Example: `1.06`
+
+## Minimum Original Gravity
+
+A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style.
+
+- Key Name: `:og-min`
+- Type: Double
+- Example: `1.048`
+
+## Original Gravity Range
+
+A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units.
+
+- Key Name: `:og-range`
+- Type: String
+- Example: `"1.036sg-1.050sg"`
+
+## Profile
+
+A non-empty string denoting the aroma and flavor profile of the style.
+
+- Key Name: `:profile`
+- Type: String
+- Example: `"Full-bodied and dark."`
+
+## Style Guide
+
+A non-empty string denoting the name of the style guide the style/category belongs to.
+
+- Key Name: `:style-guide`
+- Type: String
+- Example: `"BJCP"`
+
+## Style Letter
+
+A non-empty string denoting the letter used to denote the style or sub-style.
+
+- Key Name: `:style-letter`
+- Type: String
+- Example: `"A"`
+
+## Type
+
+A case-insensitive string representing the type of beverage the style dictates.
+Must be one of: "Mead", "Lager", "Ale", "Mixed", "Wheat", "Cider"
+
+- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish.
+- Cider: A fermented beverage made from fruit and water.
+- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish.
+- Mead: A fermented beverage made from honey and water.
+- Mixed: A beer style that blends two or more styles.
+- Wheat: A beer made with a large proportion of wheat malt.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"Lager"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/styles.md
+++ b/doc/specs/styles.md
@@ -73,56 +73,56 @@ A record representing a beer style.
 
 A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style.
 
-- Key Name: `:abv-max`
-- Type: Double
+- Clojure Key Name: `:abv-max`
+- Clojure Type: Double
 - Example: `0.04`
 
 ## Abv Min
 
 A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style.
 
-- Key Name: `:abv-min`
-- Type: Double
+- Clojure Key Name: `:abv-min`
+- Clojure Type: Double
 - Example: `0.032`
 
 ## Abv Range
 
 A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units.
 
-- Key Name: `:abv-range`
-- Type: String
+- Clojure Key Name: `:abv-range`
+- Clojure Type: String
 - Example: `"8.0-11.2%"`
 
 ## Maximum Carbonation
 
 A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2.
 
-- Key Name: `:carb-max`
-- Type: Double
+- Clojure Key Name: `:carb-max`
+- Clojure Type: Double
 - Example: `2.2`
 
 ## Minimum Carbonation
 
 A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2.
 
-- Key Name: `:carb-min`
-- Type: Double
+- Clojure Key Name: `:carb-min`
+- Clojure Type: Double
 - Example: `1.5`
 
 ## Carbonation Range
 
 A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units.
 
-- Key Name: `:carb-range`
-- Type: String
+- Clojure Key Name: `:carb-range`
+- Clojure Type: String
 - Example: `"2.0-2.6 vols CO2"`
 
 ## Category
 
 A non-empty string denoting the category this style belongs to.
 
-- Key Name: `:category`
-- Type: String
+- Clojure Key Name: `:category`
+- Clojure Type: String
 - Example: `"American Lagers"`
 
 ## Category Number
@@ -130,214 +130,214 @@ A non-empty string denoting the category this style belongs to.
 A non-empty string denoting the category number of this style.
 The category number is a string because it can be a letter followed by a number, e.g. 'A1' on some guides.
 
-- Key Name: `:category-number`
-- Type: String
+- Clojure Key Name: `:category-number`
+- Clojure Type: String
 - Example: `"1"`
 
 ## Color Max
 
 A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style.
 
-- Key Name: `:color-max`
-- Type: Double
+- Clojure Key Name: `:color-max`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Color Min
 
 A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style.
 
-- Key Name: `:color-min`
-- Type: Double
+- Clojure Key Name: `:color-min`
+- Clojure Type: Double
 - Example: `32.0`
 
 ## Color Range
 
 A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units.
 
-- Key Name: `:color-range`
-- Type: String
+- Clojure Key Name: `:color-range`
+- Clojure Type: String
 - Example: `"10 - 22 SRM"`
 
 ## Display Color Max
 
 A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units.
 
-- Key Name: `:display-color-max`
-- Type: String
+- Clojure Key Name: `:display-color-max`
+- Clojure Type: String
 - Example: `"40 SRM"`
 
 ## Display Color Min
 
 A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units.
 
-- Key Name: `:display-color-min`
-- Type: String
+- Clojure Key Name: `:display-color-min`
+- Clojure Type: String
 - Example: `"32SRM"`
 
 ## Display Final Gravity Max
 
 A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-fg-max`
-- Type: String
+- Clojure Key Name: `:display-fg-max`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Display Final Gravity Min
 
 A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-fg-min`
-- Type: String
+- Clojure Key Name: `:display-fg-min`
+- Clojure Type: String
 - Example: `"1.036sg"`
 
 ## Display Original Gravity Max
 
 A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-og-max`
-- Type: String
+- Clojure Key Name: `:display-og-max`
+- Clojure Type: String
 - Example: `"1.050sg"`
 
 ## Display Original Gravity Min
 
 A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units.
 
-- Key Name: `:display-og-min`
-- Type: String
+- Clojure Key Name: `:display-og-min`
+- Clojure Type: String
 - Example: `"1.036sg"`
 
 ## Examples
 
 A non-empty string denoting example beers of this style.
 
-- Key Name: `:examples`
-- Type: String
+- Clojure Key Name: `:examples`
+- Clojure Type: String
 - Example: `"Every overly citrus IPA on the market."`
 
 ## Maximum Final Gravity
 
 A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style.
 
-- Key Name: `:fg-max`
-- Type: Double
+- Clojure Key Name: `:fg-max`
+- Clojure Type: Double
 - Example: `1.06`
 
 ## Minimum Final Gravity
 
 A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style.
 
-- Key Name: `:fg-min`
-- Type: Double
+- Clojure Key Name: `:fg-min`
+- Clojure Type: Double
 - Example: `1.048`
 
 ## Final Gravity Range
 
 A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units.
 
-- Key Name: `:fg-range`
-- Type: String
+- Clojure Key Name: `:fg-range`
+- Clojure Type: String
 - Example: `"1.036sg-1.050sg"`
 
 ## Maximum International Bittering Units
 
 A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style.
 
-- Key Name: `:ibu-max`
-- Type: Double
+- Clojure Key Name: `:ibu-max`
+- Clojure Type: Double
 - Example: `40.0`
 
 ## Minimum International Bittering Units
 
 A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style.
 
-- Key Name: `:ibu-min`
-- Type: Double
+- Clojure Key Name: `:ibu-min`
+- Clojure Type: Double
 - Example: `32.0`
 
 ## International Bittering Units Range
 
 A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units.
 
-- Key Name: `:ibu-range`
-- Type: String
+- Clojure Key Name: `:ibu-range`
+- Clojure Type: String
 - Example: `"10-20IBUs"`
 
 ## Ingredients
 
 A non-empty string denoting the suggested ingredients for the style.
 
-- Key Name: `:ingredients`
-- Type: String
+- Clojure Key Name: `:ingredients`
+- Clojure Type: String
 - Example: `"water, barley, and hops."`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Maximum Original Gravity
 
 A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style.
 
-- Key Name: `:og-max`
-- Type: Double
+- Clojure Key Name: `:og-max`
+- Clojure Type: Double
 - Example: `1.06`
 
 ## Minimum Original Gravity
 
 A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style.
 
-- Key Name: `:og-min`
-- Type: Double
+- Clojure Key Name: `:og-min`
+- Clojure Type: Double
 - Example: `1.048`
 
 ## Original Gravity Range
 
 A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units.
 
-- Key Name: `:og-range`
-- Type: String
+- Clojure Key Name: `:og-range`
+- Clojure Type: String
 - Example: `"1.036sg-1.050sg"`
 
 ## Profile
 
 A non-empty string denoting the aroma and flavor profile of the style.
 
-- Key Name: `:profile`
-- Type: String
+- Clojure Key Name: `:profile`
+- Clojure Type: String
 - Example: `"Full-bodied and dark."`
 
 ## Style Guide
 
 A non-empty string denoting the name of the style guide the style/category belongs to.
 
-- Key Name: `:style-guide`
-- Type: String
+- Clojure Key Name: `:style-guide`
+- Clojure Type: String
 - Example: `"BJCP"`
 
 ## Style Letter
 
 A non-empty string denoting the letter used to denote the style or sub-style.
 
-- Key Name: `:style-letter`
-- Type: String
+- Clojure Key Name: `:style-letter`
+- Clojure Type: String
 - Example: `"A"`
 
 ## Type
 
-A case-insensitive string representing the type of beverage the style dictates.
-Must be one of: "Mead", "Lager", "Ale", "Mixed", "Wheat", "Cider"
+A case-sensitive string representing the type of beverage the style dictates.
+Must be one of: "Lager", "Cider", "Mixed", "Mead", "Wheat", "Ale"
 
 - Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish.
 - Cider: A fermented beverage made from fruit and water.
@@ -346,14 +346,14 @@ Must be one of: "Mead", "Lager", "Ale", "Mixed", "Wheat", "Cider"
 - Mixed: A beer style that blends two or more styles.
 - Wheat: A beer made with a large proportion of wheat malt.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"Lager"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/water.md
+++ b/doc/specs/water.md
@@ -48,96 +48,96 @@ A record representing the water in a beer recipe.
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient
+A ::kilogram value representing the amount of a particular ingredient.
 
-- Key Name: `:amount`
-- Type: Double
+- Clojure Key Name: `:amount`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Bicarbonate
 
 A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million.
 
-- Key Name: `:bicarbonate`
-- Type: Double
+- Clojure Key Name: `:bicarbonate`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Calcium
 
 A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million.
 
-- Key Name: `:calcium`
-- Type: Double
+- Clojure Key Name: `:calcium`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Chloride
 
 A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million.
 
-- Key Name: `:chloride`
-- Type: Double
+- Clojure Key Name: `:chloride`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Display Amount
 
-A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
-- Key Name: `:display-amount`
-- Type: String
+- Clojure Key Name: `:display-amount`
+- Clojure Type: String
 - Example: `"100 g"`
 
 ## Magnesium
 
 A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million.
 
-- Key Name: `:magnesium`
-- Type: Double
+- Clojure Key Name: `:magnesium`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## PH
 
 A positive IEEE-754 floating point number representing the PH of the water.
 
-- Key Name: `:ph`
-- Type: Double
+- Clojure Key Name: `:ph`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Sodium
 
 A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million.
 
-- Key Name: `:sodium`
-- Type: Double
+- Clojure Key Name: `:sodium`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Sulfate
 
 A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million.
 
-- Key Name: `:sulfate`
-- Type: Double
+- Clojure Key Name: `:sulfate`
+- Clojure Type: Double
 - Example: `2.5`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/doc/specs/water.md
+++ b/doc/specs/water.md
@@ -2,7 +2,9 @@
 
 ## Waters Wrapper
 
-A `::waters-wrapper` record.
+A `::waters-wrapper` record set.
+
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -19,6 +21,8 @@ A vector of valid `::water` records.
 ## Water Wrapper
 
 A `::water` record wrapped in a `:water` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -48,8 +52,12 @@ A record representing the water in a beer recipe.
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient.
+A value representing the amount of a particular ingredient.
+When measuring weight, this is in kilograms.
+When measuring volume, this is in liters.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Kilogram, Liter
 - Clojure Key Name: `:amount`
 - Clojure Type: Double
 - Example: `12.5`
@@ -58,6 +66,7 @@ A ::kilogram value representing the amount of a particular ingredient.
 
 A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:bicarbonate`
 - Clojure Type: Double
 - Example: `2.5`
@@ -66,6 +75,7 @@ A positive IEEE-754 floating point number representing the amount of bicarbonate
 
 A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:calcium`
 - Clojure Type: Double
 - Example: `2.5`
@@ -74,6 +84,7 @@ A positive IEEE-754 floating point number representing the amount of calcium (Ca
 
 A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:chloride`
 - Clojure Type: Double
 - Example: `2.5`
@@ -82,6 +93,7 @@ A positive IEEE-754 floating point number representing the amount of chloride (C
 
 A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-amount`
 - Clojure Type: String
 - Example: `"100 g"`
@@ -90,6 +102,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:magnesium`
 - Clojure Type: Double
 - Example: `2.5`
@@ -98,6 +111,7 @@ A positive IEEE-754 floating point number representing the amount of magnesium (
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -106,6 +120,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -114,6 +129,7 @@ A non-empty string representing any notes about the subject.
 
 A positive IEEE-754 floating point number representing the PH of the water.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:ph`
 - Clojure Type: Double
 - Example: `2.5`
@@ -122,6 +138,7 @@ A positive IEEE-754 floating point number representing the PH of the water.
 
 A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:sodium`
 - Clojure Type: Double
 - Example: `2.5`
@@ -130,6 +147,7 @@ A positive IEEE-754 floating point number representing the amount of sodium (Na)
 
 A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million.
 
+- BeerXML Type: `Floating Point`
 - Clojure Key Name: `:sulfate`
 - Clojure Type: Double
 - Example: `2.5`
@@ -138,6 +156,7 @@ A positive IEEE-754 floating point number representing the amount of sulfate (SO
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/water.md
+++ b/doc/specs/water.md
@@ -1,0 +1,143 @@
+# Water Records
+
+## Waters Wrapper
+
+A `::waters-wrapper` record.
+
+### Wrapped Record
+
+- [Waters](#waters)
+
+## Waters
+
+A vector of valid `::water` records.
+
+### Collection Type
+
+- [Water Wrapper](#water-wrapper)
+
+## Water Wrapper
+
+A `::water` record wrapped in a `:water` map.
+
+### Wrapped Record
+
+- [Water](#water)
+
+## Water
+
+A record representing the water in a beer recipe.
+
+### Required Keys
+
+- [Amount](#amount)
+- [Bicarbonate](#bicarbonate)
+- [Calcium](#calcium)
+- [Chloride](#chloride)
+- [Magnesium](#magnesium)
+- [Name](#name)
+- [Sodium](#sodium)
+- [Sulfate](#sulfate)
+- [Version](#version)
+
+### Optional Keys
+
+- [Display Amount](#display-amount)
+- [Notes](#notes)
+- [PH](#ph)
+
+## Amount
+
+A ::kilogram value representing the amount of a particular ingredient
+
+- Key Name: `:amount`
+- Type: Double
+- Example: `12.5`
+
+## Bicarbonate
+
+A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million.
+
+- Key Name: `:bicarbonate`
+- Type: Double
+- Example: `2.5`
+
+## Calcium
+
+A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million.
+
+- Key Name: `:calcium`
+- Type: Double
+- Example: `2.5`
+
+## Chloride
+
+A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million.
+
+- Key Name: `:chloride`
+- Type: Double
+- Example: `2.5`
+
+## Display Amount
+
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+
+- Key Name: `:display-amount`
+- Type: String
+- Example: `"100 g"`
+
+## Magnesium
+
+A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million.
+
+- Key Name: `:magnesium`
+- Type: Double
+- Example: `2.5`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## PH
+
+A positive IEEE-754 floating point number representing the PH of the water.
+
+- Key Name: `:ph`
+- Type: Double
+- Example: `2.5`
+
+## Sodium
+
+A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million.
+
+- Key Name: `:sodium`
+- Type: Double
+- Example: `2.5`
+
+## Sulfate
+
+A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million.
+
+- Key Name: `:sulfate`
+- Type: Double
+- Example: `2.5`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/yeast.md
+++ b/doc/specs/yeast.md
@@ -2,7 +2,9 @@
 
 ## Yeasts Wrapper
 
-A `::yeasts-wrapper` record.
+A `::yeasts-wrapper` record set.
+
+- BeerXML Type: `Record Set`
 
 ### Wrapped Record
 
@@ -19,6 +21,8 @@ A vector of valid `::yeast` records.
 ## Yeast Wrapper
 
 A `::yeast` record wrapped in a `:yeast` map.
+
+- BeerXML Type: `Record`
 
 ### Wrapped Record
 
@@ -50,8 +54,8 @@ A record representing the yeast in a beer recipe.
 - [Inventory](#inventory)
 - [Laboratory](#laboratory)
 - [Max Reuse](#max-reuse)
-- [Max Temperature](#max-temperature)
-- [Min Temperature](#min-temperature)
+- [Maximum Temperature](#maximum-temperature)
+- [Minimum Temperature](#minimum-temperature)
 - [Notes](#notes)
 - [Product Id](#product-id)
 - [Times Cultured](#times-cultured)
@@ -61,14 +65,19 @@ A record representing the yeast in a beer recipe.
 A boolean representing if this yeast was added for a secondary fermentation.
 When absent, assume false.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:add-to-secondary`
 - Clojure Type: Spec
 - Example: `false`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient.
+A value representing the amount of a particular ingredient.
+When measuring weight, this is in kilograms.
+When measuring volume, this is in liters.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Units: Kilogram, Liter
 - Clojure Key Name: `:amount`
 - Clojure Type: Double
 - Example: `12.5`
@@ -78,6 +87,7 @@ A ::kilogram value representing the amount of a particular ingredient.
 A boolean representing if the amount of the substance is measured in kilograms.
 When absent, assume false and that the amount of substance is measured in liters.
 
+- BeerXML Type: `Boolean`
 - Clojure Key Name: `:amount-is-weight`
 - Clojure Type: Boolean
 - Example: `false`
@@ -86,6 +96,7 @@ When absent, assume false and that the amount of substance is measured in liters
 
 A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide.
 
+- BeerXML Type: `Percentage`
 - Clojure Key Name: `:attenuation`
 - Clojure Type: Double
 - Example: `73.2`
@@ -94,6 +105,7 @@ A positive IEEE-754 floating point number representing the percent of malt sugar
 
 A non-empty string denoting the styles of beer this yeast is best suited for.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:best-for`
 - Clojure Type: String
 - Example: `"WLP008"`
@@ -102,6 +114,7 @@ A non-empty string denoting the styles of beer this yeast is best suited for.
 
 A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:culture-date`
 - Clojure Type: String
 - Example: `"10/10/2020"`
@@ -110,6 +123,7 @@ A non-empty string denoting a display value for the date the yeast sample was la
 
 A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:disp-max-temp`
 - Clojure Type: String
 - Example: `"75F"`
@@ -118,6 +132,7 @@ A non-empty string denoting a display value for the maximum fermentation tempera
 
 A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:disp-min-temp`
 - Clojure Type: String
 - Example: `"68F"`
@@ -126,6 +141,7 @@ A non-empty string denoting a display value for the minimum fermentation tempera
 
 A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:display-amount`
 - Clojure Type: String
 - Example: `"100 g"`
@@ -140,6 +156,7 @@ Must be one of: "Medium", "Very high", "High", "Low"
 - High: The yeast settles out of suspension quickly.
 - Very High: The yeast settles out of suspension very quickly.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:flocculation`
 - Clojure Type: String
 - Example: `"High"`
@@ -154,6 +171,7 @@ Must be one of: "Culture", "Slant", "Dry", "Liquid"
 - Slant: Yeast cultivated on a solid growth medium.
 - Culture: Yeast cultivated from previous fermentations.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:form`
 - Clojure Type: String
 - Example: `"Ale"`
@@ -162,6 +180,7 @@ Must be one of: "Culture", "Slant", "Dry", "Liquid"
 
 A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:inventory`
 - Clojure Type: String
 - Example: `"100 lbs"`
@@ -170,6 +189,7 @@ A non-empty string denoting a display value for the amount of the ingredient in 
 
 A non-empty string denoting the laboratory that cultivated the yeast.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:laboratory`
 - Clojure Type: String
 - Example: `"White Labs"`
@@ -178,22 +198,27 @@ A non-empty string denoting the laboratory that cultivated the yeast.
 
 A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:max-reuse`
 - Clojure Type: Long
 - Example: `3`
 
-## Max Temperature
+## Maximum Temperature
 
 An IEEE-754 floating point number representing the maximum recommended temperature of fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:max-temperature`
 - Clojure Type: Double
 - Example: `23.9`
 
-## Min Temperature
+## Minimum Temperature
 
 An IEEE-754 floating point number representing the minimum recommended temperature of fermentation.
 
+- BeerXML Type: `Floating Point`
+- BeerXML Unit: Degrees Celsius
 - Clojure Key Name: `:min-temperature`
 - Clojure Type: Double
 - Example: `19.5`
@@ -202,6 +227,7 @@ An IEEE-754 floating point number representing the minimum recommended temperatu
 
 A non-empty string representing the name of the ingredient.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:name`
 - Clojure Type: String
 - Example: `"Citra"`
@@ -210,6 +236,7 @@ A non-empty string representing the name of the ingredient.
 
 A non-empty string representing any notes about the subject.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:notes`
 - Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
@@ -218,6 +245,7 @@ A non-empty string representing any notes about the subject.
 
 A non-empty string denoting the product label or id number that identifies the strain of yeast.
 
+- BeerXML Type: `Text`
 - Clojure Key Name: `:product-id`
 - Clojure Type: String
 - Example: `"WLP008"`
@@ -227,6 +255,7 @@ A non-empty string denoting the product label or id number that identifies the s
 A non-negative integer representing the number of times this yeast has been harvested and re-used.
 A value of zero assumes the yeast came directly from the manufacturer.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:times-cultured`
 - Clojure Type: Long
 - Example: `1`
@@ -242,6 +271,7 @@ Must be one of: "Lager", "Wheat", "Ale", "Champagne", "Wine"
 - Wine: Yeast traditionally used in wine making.
 - Champagne: Yeast traditionally used in champagne making, offering a dry taste.
 
+- BeerXML Type: `List`
 - Clojure Key Name: `:type`
 - Clojure Type: String
 - Example: `"Ale"`
@@ -250,6 +280,7 @@ Must be one of: "Lager", "Wheat", "Ale", "Champagne", "Wine"
 
 An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
+- BeerXML Type: `Integer`
 - Clojure Key Name: `:version`
 - Clojure Type: Long
 - Example: `1`

--- a/doc/specs/yeast.md
+++ b/doc/specs/yeast.md
@@ -1,0 +1,255 @@
+# Yeast Records
+
+## Yeasts Wrapper
+
+A `::yeasts-wrapper` record.
+
+### Wrapped Record
+
+- [Yeasts](#yeasts)
+
+## Yeasts
+
+A vector of valid `::yeast` records.
+
+### Collection Type
+
+- [Yeast Wrapper](#yeast-wrapper)
+
+## Yeast Wrapper
+
+A `::yeast` record wrapped in a `:yeast` map.
+
+### Wrapped Record
+
+- [Yeast](#yeast)
+
+## Yeast
+
+A record representing the yeast in a beer recipe.
+
+### Required Keys
+
+- [Amount](#amount)
+- [Form](#form)
+- [Name](#name)
+- [Type](#type)
+- [Version](#version)
+
+### Optional Keys
+
+- [Add To Secondary](#add-to-secondary)
+- [Amount Is Weight](#amount-is-weight)
+- [Attenuation](#attenuation)
+- [Best For](#best-for)
+- [Culture Date](#culture-date)
+- [Display Maximum Temperature](#display-maximum-temperature)
+- [Display Minimum Temperature](#display-minimum-temperature)
+- [Display Amount](#display-amount)
+- [Flocculation](#flocculation)
+- [Inventory](#inventory)
+- [Laboratory](#laboratory)
+- [Max Reuse](#max-reuse)
+- [Max Temperature](#max-temperature)
+- [Min Temperature](#min-temperature)
+- [Notes](#notes)
+- [Product Id](#product-id)
+- [Times Cultured](#times-cultured)
+
+## Add To Secondary
+
+A boolean representing if this yeast was added for a secondary fermentation.
+When absent, assume false.
+
+- Key Name: `:add-to-secondary`
+- Type: Spec
+- Example: `false`
+
+## Amount
+
+A ::kilogram value representing the amount of a particular ingredient
+
+- Key Name: `:amount`
+- Type: Double
+- Example: `12.5`
+
+## Amount Is Weight
+
+A boolean representing if the amount of the substance is measured in kilograms.
+When absent, assume false and that the amount of substance is measured in liters.
+
+- Key Name: `:amount-is-weight`
+- Type: Boolean
+- Example: `false`
+
+## Attenuation
+
+A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide.
+
+- Key Name: `:attenuation`
+- Type: Double
+- Example: `73.2`
+
+## Best For
+
+A non-empty string denoting the styles of beer this yeast is best suited for.
+
+- Key Name: `:best-for`
+- Type: String
+- Example: `"WLP008"`
+
+## Culture Date
+
+A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure.
+
+- Key Name: `:culture-date`
+- Type: String
+- Example: `"10/10/2020"`
+
+## Display Maximum Temperature
+
+A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units.
+
+- Key Name: `:disp-max-temp`
+- Type: String
+- Example: `"75F"`
+
+## Display Minimum Temperature
+
+A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units.
+
+- Key Name: `:disp-min-temp`
+- Type: String
+- Example: `"68F"`
+
+## Display Amount
+
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+
+- Key Name: `:display-amount`
+- Type: String
+- Example: `"100 g"`
+
+## Flocculation
+
+A case-insensitive string representing how dense of a floc the yeast will form.
+Must be one of: "Low", "High", "Medium", "Very high"
+
+- Low: The yeast settles out of suspension slowly.
+- Medium: The yeast settles out of suspension at a moderate rate.
+- High: The yeast settles out of suspension quickly.
+- Very High: The yeast settles out of suspension very quickly.
+
+- Key Name: `:flocculation`
+- Type: String
+- Example: `"High"`
+
+## Form
+
+A case-insensitive string representing the form of the yeast added to the beer.
+Must be one of: "Culture", "Dry", "Slant", "Liquid"
+
+- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars.
+- Dry: Dry yeast sold in a dehydrated state to extend shelf life.
+- Slant: Yeast cultivated on a solid growth medium.
+- Culture: Yeast cultivated from previous fermentations.
+
+- Key Name: `:form`
+- Type: String
+- Example: `"Ale"`
+
+## Inventory
+
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+
+- Key Name: `:inventory`
+- Type: String
+- Example: `"100 lbs"`
+
+## Laboratory
+
+A non-empty string denoting the laboratory that cultivated the yeast.
+
+- Key Name: `:laboratory`
+- Type: String
+- Example: `"White Labs"`
+
+## Max Reuse
+
+A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured.
+
+- Key Name: `:max-reuse`
+- Type: Long
+- Example: `3`
+
+## Max Temperature
+
+An IEEE-754 floating point number representing the maximum recommended temperature of fermentation.
+
+- Key Name: `:max-temperature`
+- Type: Double
+- Example: `23.9`
+
+## Min Temperature
+
+An IEEE-754 floating point number representing the minimum recommended temperature of fermentation.
+
+- Key Name: `:min-temperature`
+- Type: Double
+- Example: `19.5`
+
+## Name
+
+A non-empty string representing the name of the ingredient
+
+- Key Name: `:name`
+- Type: String
+- Example: `"Citra"`
+
+## Notes
+
+A non-empty string representing any notes about the subject
+
+- Key Name: `:notes`
+- Type: String
+- Example: `"A wonderful, zesty aroma"`
+
+## Product Id
+
+A non-empty string denoting the product label or id number that identifies the strain of yeast.
+
+- Key Name: `:product-id`
+- Type: String
+- Example: `"WLP008"`
+
+## Times Cultured
+
+A non-negative integer representing the number of times this yeast has been harvested and re-used.
+A value of zero assumes the yeast came directly from the manufacturer.
+
+- Key Name: `:times-cultured`
+- Type: Long
+- Example: `1`
+
+## Type
+
+A case-insensitive string representing the type of yeast added to the beer.
+Must be one of: "Wine", "Lager", "Ale", "Wheat", "Champagne"
+
+- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer.
+- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer.
+- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer.
+- Wine: Yeast traditionally used in wine making.
+- Champagne: Yeast traditionally used in champagne making, offering a dry taste.
+
+- Key Name: `:type`
+- Type: String
+- Example: `"Ale"`
+
+## Version
+
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+
+- Key Name: `:version`
+- Type: Long
+- Example: `1`

--- a/doc/specs/yeast.md
+++ b/doc/specs/yeast.md
@@ -61,16 +61,16 @@ A record representing the yeast in a beer recipe.
 A boolean representing if this yeast was added for a secondary fermentation.
 When absent, assume false.
 
-- Key Name: `:add-to-secondary`
-- Type: Spec
+- Clojure Key Name: `:add-to-secondary`
+- Clojure Type: Spec
 - Example: `false`
 
 ## Amount
 
-A ::kilogram value representing the amount of a particular ingredient
+A ::kilogram value representing the amount of a particular ingredient.
 
-- Key Name: `:amount`
-- Type: Double
+- Clojure Key Name: `:amount`
+- Clojure Type: Double
 - Example: `12.5`
 
 ## Amount Is Weight
@@ -78,148 +78,148 @@ A ::kilogram value representing the amount of a particular ingredient
 A boolean representing if the amount of the substance is measured in kilograms.
 When absent, assume false and that the amount of substance is measured in liters.
 
-- Key Name: `:amount-is-weight`
-- Type: Boolean
+- Clojure Key Name: `:amount-is-weight`
+- Clojure Type: Boolean
 - Example: `false`
 
 ## Attenuation
 
 A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide.
 
-- Key Name: `:attenuation`
-- Type: Double
+- Clojure Key Name: `:attenuation`
+- Clojure Type: Double
 - Example: `73.2`
 
 ## Best For
 
 A non-empty string denoting the styles of beer this yeast is best suited for.
 
-- Key Name: `:best-for`
-- Type: String
+- Clojure Key Name: `:best-for`
+- Clojure Type: String
 - Example: `"WLP008"`
 
 ## Culture Date
 
 A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure.
 
-- Key Name: `:culture-date`
-- Type: String
+- Clojure Key Name: `:culture-date`
+- Clojure Type: String
 - Example: `"10/10/2020"`
 
 ## Display Maximum Temperature
 
 A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units.
 
-- Key Name: `:disp-max-temp`
-- Type: String
+- Clojure Key Name: `:disp-max-temp`
+- Clojure Type: String
 - Example: `"75F"`
 
 ## Display Minimum Temperature
 
 A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units.
 
-- Key Name: `:disp-min-temp`
-- Type: String
+- Clojure Key Name: `:disp-min-temp`
+- Clojure Type: String
 - Example: `"68F"`
 
 ## Display Amount
 
-A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units.
 
-- Key Name: `:display-amount`
-- Type: String
+- Clojure Key Name: `:display-amount`
+- Clojure Type: String
 - Example: `"100 g"`
 
 ## Flocculation
 
-A case-insensitive string representing how dense of a floc the yeast will form.
-Must be one of: "Low", "High", "Medium", "Very high"
+A case-sensitive string representing how dense of a floc the yeast will form.
+Must be one of: "Medium", "Very high", "High", "Low"
 
 - Low: The yeast settles out of suspension slowly.
 - Medium: The yeast settles out of suspension at a moderate rate.
 - High: The yeast settles out of suspension quickly.
 - Very High: The yeast settles out of suspension very quickly.
 
-- Key Name: `:flocculation`
-- Type: String
+- Clojure Key Name: `:flocculation`
+- Clojure Type: String
 - Example: `"High"`
 
 ## Form
 
-A case-insensitive string representing the form of the yeast added to the beer.
-Must be one of: "Culture", "Dry", "Slant", "Liquid"
+A case-sensitive string representing the form of the yeast added to the beer.
+Must be one of: "Culture", "Slant", "Dry", "Liquid"
 
 - Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars.
 - Dry: Dry yeast sold in a dehydrated state to extend shelf life.
 - Slant: Yeast cultivated on a solid growth medium.
 - Culture: Yeast cultivated from previous fermentations.
 
-- Key Name: `:form`
-- Type: String
+- Clojure Key Name: `:form`
+- Clojure Type: String
 - Example: `"Ale"`
 
 ## Inventory
 
-A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units
+A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units.
 
-- Key Name: `:inventory`
-- Type: String
+- Clojure Key Name: `:inventory`
+- Clojure Type: String
 - Example: `"100 lbs"`
 
 ## Laboratory
 
 A non-empty string denoting the laboratory that cultivated the yeast.
 
-- Key Name: `:laboratory`
-- Type: String
+- Clojure Key Name: `:laboratory`
+- Clojure Type: String
 - Example: `"White Labs"`
 
 ## Max Reuse
 
 A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured.
 
-- Key Name: `:max-reuse`
-- Type: Long
+- Clojure Key Name: `:max-reuse`
+- Clojure Type: Long
 - Example: `3`
 
 ## Max Temperature
 
 An IEEE-754 floating point number representing the maximum recommended temperature of fermentation.
 
-- Key Name: `:max-temperature`
-- Type: Double
+- Clojure Key Name: `:max-temperature`
+- Clojure Type: Double
 - Example: `23.9`
 
 ## Min Temperature
 
 An IEEE-754 floating point number representing the minimum recommended temperature of fermentation.
 
-- Key Name: `:min-temperature`
-- Type: Double
+- Clojure Key Name: `:min-temperature`
+- Clojure Type: Double
 - Example: `19.5`
 
 ## Name
 
-A non-empty string representing the name of the ingredient
+A non-empty string representing the name of the ingredient.
 
-- Key Name: `:name`
-- Type: String
+- Clojure Key Name: `:name`
+- Clojure Type: String
 - Example: `"Citra"`
 
 ## Notes
 
-A non-empty string representing any notes about the subject
+A non-empty string representing any notes about the subject.
 
-- Key Name: `:notes`
-- Type: String
+- Clojure Key Name: `:notes`
+- Clojure Type: String
 - Example: `"A wonderful, zesty aroma"`
 
 ## Product Id
 
 A non-empty string denoting the product label or id number that identifies the strain of yeast.
 
-- Key Name: `:product-id`
-- Type: String
+- Clojure Key Name: `:product-id`
+- Clojure Type: String
 - Example: `"WLP008"`
 
 ## Times Cultured
@@ -227,14 +227,14 @@ A non-empty string denoting the product label or id number that identifies the s
 A non-negative integer representing the number of times this yeast has been harvested and re-used.
 A value of zero assumes the yeast came directly from the manufacturer.
 
-- Key Name: `:times-cultured`
-- Type: Long
+- Clojure Key Name: `:times-cultured`
+- Clojure Type: Long
 - Example: `1`
 
 ## Type
 
-A case-insensitive string representing the type of yeast added to the beer.
-Must be one of: "Wine", "Lager", "Ale", "Wheat", "Champagne"
+A case-sensitive string representing the type of yeast added to the beer.
+Must be one of: "Lager", "Wheat", "Ale", "Champagne", "Wine"
 
 - Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer.
 - Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer.
@@ -242,14 +242,14 @@ Must be one of: "Wine", "Lager", "Ale", "Wheat", "Champagne"
 - Wine: Yeast traditionally used in wine making.
 - Champagne: Yeast traditionally used in champagne making, offering a dry taste.
 
-- Key Name: `:type`
-- Type: String
+- Clojure Key Name: `:type`
+- Clojure Type: String
 - Example: `"Ale"`
 
 ## Version
 
-An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists
+An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists.
 
-- Key Name: `:version`
-- Type: Long
+- Clojure Key Name: `:version`
+- Clojure Type: Long
 - Example: `1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "common-beer-format",
       "version": "2.2.2",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "karma": "^6.3.16",
         "karma-chrome-launcher": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-beer-format",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "common-beer-format",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "karma": "^6.3.16",
@@ -562,9 +562,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-beer-format",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "An implementation  of the BeerXML spec in multiple formats",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "type": "git",
     "url": "git+https://github.com/Wall-Brew-Co/common-beer-format.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Wall Brew Co",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Wall-Brew-Co/common-beer-format/issues"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/common-beer-format</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/common-beer-format.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/common-beer-format.git</developerConnection>
-    <tag>b6e31caf397b82455954f1c055357d6b37e1c398</tag>
+    <tag>ff00b960d68bf848c4f4b07804f6810963db4944</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -87,28 +87,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.json</artifactId>
-      <version>2.5.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.xml</artifactId>
-      <version>0.2.0-alpha9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>spec.alpha</artifactId>
-      <version>0.4.233</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>test.check</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.wallbrew</groupId>
       <artifactId>clj-xml</artifactId>
       <version>1.9.0</version>
@@ -124,6 +102,12 @@
       <groupId>doo</groupId>
       <artifactId>doo</artifactId>
       <version>0.1.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>data.json</artifactId>
+      <version>2.5.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>common-beer-format</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.2</version>
+  <version>2.3.0</version>
   <name>common-beer-format</name>
   <description>An implementation of the BeerXML spec in multiple formats.</description>
   <url>https://github.com/Wall-Brew-Co/common-beer-format</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/common-beer-format</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/common-beer-format.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/common-beer-format.git</developerConnection>
-    <tag>ff00b960d68bf848c4f4b07804f6810963db4944</tag>
+    <tag>c4485cd2d249812b882a1d69a807e1452a502e11</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/common-beer-format "2.2.2"
+(defproject com.wallbrew/common-beer-format "2.3.0"
   :description "An implementation of the BeerXML spec in multiple formats."
   :url "https://github.com/Wall-Brew-Co/common-beer-format"
   :license {:name         "MIT"

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,7 @@
                                       [doo "0.1.11"]
                                       [org.clojure/data.json "2.5.0"]]
                        :plugins      [[lein-doo "0.1.11"]]}
-             :export {:source-paths ["src" "dev"]
-                      :dependencies [[com.wallbrew/clj-xml "1.9.0"]
-                                     [org.clojure/data.json "2.5.0"]]}}
+             :export  {:source-paths ["src" "dev"]}}
   :deploy-branches ["master"]
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :username      :env/clojars_user
@@ -34,7 +32,8 @@
 
   :min-lein-version "2.5.3"
 
-  :aliases {"test-build" ["do" "clean" ["cljsbuild" "once" "test"] ["doo" "once"] ["test"]]}
+  :aliases {"test-build"   ["do" "clean" ["cljsbuild" "once" "test"] ["doo" "once"] ["test"]]
+            "export-specs" ["with-profile" "export" "run" "-m" "common-beer-format.spec-export/render-specs!"]}
 
   :cljsbuild {:builds [{:id           "test"
                         :source-paths ["src" "test"]

--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,7 @@
   :dependencies [[metosin/spec-tools "0.10.6"]
                  [nnichols "1.1.0"]
                  [org.clojure/clojure "1.11.2"]
-                 [org.clojure/clojurescript "1.11.132" :scope "provided"]
-                 [org.clojure/data.json "2.5.0"]
-                 [org.clojure/data.xml "0.2.0-alpha9"]
-                 [org.clojure/spec.alpha "0.4.233"]
-                 [org.clojure/test.check "1.1.1"]]
+                 [org.clojure/clojurescript "1.11.132" :scope "provided"]]
   :plugins [[com.github.clj-kondo/lein-clj-kondo "2024.03.13"]
             [com.wallbrew/lein-sealog "1.2.1"]
             [lein-cljsbuild "1.1.8"]
@@ -25,9 +21,11 @@
              :dev     {:dependencies [[com.wallbrew/clj-xml "1.9.0"]
                                       [com.wallbrew/spoon "1.2.2"]
                                       [doo "0.1.11"]
-                                      [org.clojure/data.json "2.5.0"]
-                                      [org.clojure/data.xml "0.2.0-alpha9"]]
-                       :plugins      [[lein-doo "0.1.11"]]}}
+                                      [org.clojure/data.json "2.5.0"]]
+                       :plugins      [[lein-doo "0.1.11"]]}
+             :export {:source-paths ["src" "dev"]
+                      :dependencies [[com.wallbrew/clj-xml "1.9.0"]
+                                     [org.clojure/data.json "2.5.0"]]}}
   :deploy-branches ["master"]
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :username      :env/clojars_user

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -12,6 +12,7 @@
   "A map representing the brewing equipment used during the mash."
   :equipment)
 
+
 (def equipments
   "A vector of equipment records."
   :equipments)
@@ -349,6 +350,7 @@
      :decode/string        #(impl/decode-wrapper %1 ::equipment %2)
      :encode/string        #(impl/encode-wrapper %1 ::equipment %2)}))
 
+
 (spec/def ::equipments
   (st/spec
     {:type          :vector
@@ -356,6 +358,7 @@
      :spec          (spec/coll-of ::equipment-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::equipment-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::equipment-wrapper %2)}))
+
 
 (spec/def ::equipments-wrapper
   (st/spec

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -49,7 +49,7 @@
 
 
 (def tun-specific-heat
-  "The specific heat of the mashtun in Calories per gram-degree Celsius."
+  "The specific heat of the mash tun in Calories per gram-degree Celsius."
   :tun-specific-heat)
 
 
@@ -175,7 +175,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius."
+     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
      :json-schema/example "0.2"}))
 
 
@@ -214,10 +214,10 @@
 (spec/def ::calc-boil-volume
   (st/spec
     {:spec                ::prim/boolean
-     impl/display-name-key "Calculate Boil Volume."
+     impl/display-name-key "Calculate Boil Volume"
      :description         (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
                                           "When absent, assume false."
-                                          "When true, then boil-size = (batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)")
+                                          "When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`")
      :json-schema/example "true."
      :decode/string       impl/decode-boolean
      :encode/string       impl/encode-boolean}))
@@ -259,7 +259,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units."
+     :description         "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
      :json-schema/example "4.5 gallons"}))
 
 

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -12,6 +12,10 @@
   "A map representing the brewing equipment used during the mash."
   :equipment)
 
+(def equipments
+  "A vector of equipment records."
+  :equipments)
+
 
 (def name
   "The name of the equipment record."
@@ -89,7 +93,7 @@
 
 
 (def notes
-  "A string containing notes about the equipment setup"
+  "A string containing notes about the equipment setup."
   :notes)
 
 
@@ -137,7 +141,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup"
+     :description         "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup."
      :json-schema/example "10.8"}))
 
 
@@ -145,7 +149,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation"
+     :description         "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation."
      :json-schema/example "5.8"}))
 
 
@@ -153,7 +157,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters"
+     :description         "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters."
      :json-schema/example "15.0"}))
 
 
@@ -161,7 +165,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/kilogram
-     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms"
+     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
      :json-schema/example "15.0"}))
 
 
@@ -170,7 +174,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius"
+     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius."
      :json-schema/example "0.2"}))
 
 
@@ -178,7 +182,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters"
+     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters."
      :json-schema/example "2.1"}))
 
 
@@ -186,7 +190,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel"
+     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel."
      :json-schema/example "0.1"}))
 
 
@@ -194,7 +198,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil"
+     :description         "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
      :json-schema/example "1.2"}))
 
 
@@ -209,10 +213,11 @@
 (spec/def ::calc-boil-volume
   (st/spec
     {:spec                ::prim/boolean
+     impl/display-name-key "Calculate Boil Volume."
      :description         (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
                                           "When absent, assume false."
                                           "When true, then boil-size = (batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)")
-     :json-schema/example "true"
+     :json-schema/example "true."
      :decode/string       impl/decode-boolean
      :encode/string       impl/encode-boolean}))
 
@@ -221,7 +226,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun"
+     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun."
      :json-schema/example "0.1"}))
 
 
@@ -229,7 +234,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins"
+     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins."
      :json-schema/example "2.1"}))
 
 
@@ -237,7 +242,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization"
+     :description         "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization."
      :json-schema/example "1.2"}))
 
 
@@ -245,7 +250,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
      :json-schema/example "5.0 gallons"}))
 
 
@@ -253,7 +258,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units."
      :json-schema/example "4.5 gallons"}))
 
 
@@ -261,7 +266,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units."
      :json-schema/example "20 liters"}))
 
 
@@ -269,7 +274,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units."
      :json-schema/example "5.5 pounds"}))
 
 
@@ -277,7 +282,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units."
      :json-schema/example "2.2 liters"}))
 
 
@@ -285,7 +290,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units."
      :json-schema/example "2.2 liters"}))
 
 
@@ -293,7 +298,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units."
      :json-schema/example "2.2 liters"}))
 
 
@@ -301,7 +306,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units."
      :json-schema/example "2.2 liters"}))
 
 
@@ -337,8 +342,24 @@
 
 (spec/def ::equipment-wrapper
   (st/spec
-    {:type          :map
-     :description   "An ::equipment record wrapped in an ::equipment map."
-     :spec          (spec/keys :req-un [::equipment])
-     :decode/string #(impl/decode-wrapper %1 ::equipment %2)
-     :encode/string #(impl/encode-wrapper %1 ::equipment %2)}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "An ::equipment record wrapped in an ::equipment map."
+     :spec                 (spec/keys :req-un [::equipment])
+     :decode/string        #(impl/decode-wrapper %1 ::equipment %2)
+     :encode/string        #(impl/encode-wrapper %1 ::equipment %2)}))
+
+(spec/def ::equipments
+  (st/spec
+    {:type          :vector
+     :description   "A vector of valid ::equipment-wrapper records."
+     :spec          (spec/coll-of ::equipment-wrapper :into [] :kind vector?)
+     :decode/string #(impl/decode-sequence %1 ::equipment-wrapper %2)
+     :encode/string #(impl/encode-sequence %1 ::equipment-wrapper %2)}))
+
+(spec/def ::equipments-wrapper
+  (st/spec
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "An ::equipment-wrapper record."
+     :spec                 (spec/keys :req-un [::equipments])}))

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -181,7 +181,7 @@
 (spec/def ::tun-specific-heat
   (st/spec
    {:type                   :double
-    :spec                   (spec/and number? #(not (neg? %)))
+    :spec                   ::prim/non-negative-number
     :gen                    impl/real-positive-double-generator
     impl/beer-xml-type-key  impl/beer-xml-floating-point
     impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
@@ -213,6 +213,7 @@
   (st/spec
    {:type                   :double
     :spec                   ::prim/percent
+    impl/display-name-key   "Evaporation Rate"
     impl/beer-xml-type-key  impl/beer-xml-percentage
     impl/beer-xml-units-key impl/beer-xml-percent-per-hour
     :description            "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
@@ -387,7 +388,7 @@
 (spec/def ::equipments
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::equipment-wrapper records."
+     :description   "A vector of valid `::equipment-wrapper` records."
      :spec          (spec/coll-of ::equipment-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::equipment-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::equipment-wrapper %2)}))
@@ -398,5 +399,5 @@
     {:type                 :map
      impl/wrapper-spec-key true
      impl/beer-xml-type-key impl/beer-xml-record-set
-     :description          "An ::equipment-wrapper record."
+     :description          "An `::equipment-wrapper` record set."
      :spec                 (spec/keys :req-un [::equipments])}))

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -140,175 +140,207 @@
 
 (spec/def ::boil-size
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup."
-     :json-schema/example "10.8"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup."
+    :json-schema/example    "10.8"}))
 
 
 (spec/def ::batch-size
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation."
-     :json-schema/example "5.8"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation."
+    :json-schema/example    "5.8"}))
 
 
 (spec/def ::tun-volume
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters."
-     :json-schema/example "15.0"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters."
+    :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-weight
   (st/spec
-    {:type                :double
-     :spec                ::prim/kilogram
-     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
-     :json-schema/example "15.0"}))
+   {:type                   :double
+    :spec                   ::prim/kilogram
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-kilogram
+    :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
+    :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-specific-heat
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
-     :json-schema/example "0.2"}))
+   {:type                   :double
+    :spec                   (spec/and number? #(not (neg? %)))
+    :gen                    impl/real-positive-double-generator
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
+    :json-schema/example    "0.2"}))
 
 
 (spec/def ::top-up-water
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters."
-     :json-schema/example "2.1"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters."
+    :json-schema/example    "2.1"}))
 
 
 (spec/def ::trub-chiller-loss
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel."
-     :json-schema/example "0.1"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel."
+    :json-schema/example    "0.1"}))
 
 
 (spec/def ::evap-rate
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
-     :json-schema/example "1.2"}))
+   {:type                   :double
+    :spec                   ::prim/percent
+    impl/beer-xml-type-key  impl/beer-xml-percentage
+    impl/beer-xml-units-key impl/beer-xml-percent-per-hour
+    :description            "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
+    :json-schema/example    "1.2"}))
 
 
 (spec/def ::boil-time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss."
-     :json-schema/example "15"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            "A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss."
+    :json-schema/example    "15"}))
 
 
 (spec/def ::calc-boil-volume
   (st/spec
-    {:spec                ::prim/boolean
-     impl/display-name-key "Calculate Boil Volume"
-     :description         (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
-                                          "When absent, assume false."
-                                          "When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`")
-     :json-schema/example "true."
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                  ::prim/boolean
+    impl/display-name-key  "Calculate Boil Volume"
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
+                                           "When absent, assume false."
+                                           "When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`")
+    :json-schema/example   "TRUE"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::lauter-deadspace
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun."
-     :json-schema/example "0.1"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun."
+    :json-schema/example    "0.1"}))
 
 
 (spec/def ::top-up-kettle
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins."
-     :json-schema/example "2.1"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins."
+    :json-schema/example    "2.1"}))
 
 
 (spec/def ::hop-utilization
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization."
-     :json-schema/example "1.2"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization."
+    :json-schema/example   "1.2"}))
 
 
 (spec/def ::display-boil-size
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
-     :json-schema/example "5.0 gallons"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
+    :json-schema/example   "5.0 gallons"}))
 
 
 (spec/def ::display-batch-size
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
-     :json-schema/example "4.5 gallons"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
+    :json-schema/example   "4.5 gallons"}))
 
 
 (spec/def ::display-tun-volume
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units."
-     :json-schema/example "20 liters"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units."
+    :json-schema/example   "20 liters"}))
 
 
 (spec/def ::display-tun-weight
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units."
-     :json-schema/example "5.5 pounds"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units."
+    :json-schema/example   "5.5 pounds"}))
 
 
 (spec/def ::display-top-up-water
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units."
-     :json-schema/example "2.2 liters"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units."
+    :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-trub-chiller-loss
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units."
-     :json-schema/example "2.2 liters"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units."
+    :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-lauter-deadspace
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units."
-     :json-schema/example "2.2 liters"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units."
+    :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-top-up-kettle
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units."
-     :json-schema/example "2.2 liters"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units."
+    :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::equipment
@@ -345,7 +377,8 @@
   (st/spec
     {:type                 :map
      impl/wrapper-spec-key true
-     :description          "An ::equipment record wrapped in an ::equipment map."
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description          "An `::equipment` record wrapped in an `:equipment` map."
      :spec                 (spec/keys :req-un [::equipment])
      :decode/string        #(impl/decode-wrapper %1 ::equipment %2)
      :encode/string        #(impl/encode-wrapper %1 ::equipment %2)}))
@@ -364,5 +397,6 @@
   (st/spec
     {:type                 :map
      impl/wrapper-spec-key true
+     impl/beer-xml-type-key impl/beer-xml-record-set
      :description          "An ::equipment-wrapper record."
      :spec                 (spec/keys :req-un [::equipments])}))

--- a/src/common_beer_format/equipment.cljc
+++ b/src/common_beer_format/equipment.cljc
@@ -140,208 +140,208 @@
 
 (spec/def ::boil-size
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup."
-    :json-schema/example    "10.8"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the pre-boil volume for the equipment setup."
+     :json-schema/example    "10.8"}))
 
 
 (spec/def ::batch-size
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation."
-    :json-schema/example    "5.8"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the target volume of the batch at the start of fermentation."
+     :json-schema/example    "5.8"}))
 
 
 (spec/def ::tun-volume
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters."
-    :json-schema/example    "15.0"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of the of the mash tun in liters."
+     :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-weight
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/kilogram
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-kilogram
-    :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
-    :json-schema/example    "15.0"}))
+    {:type                   :double
+     :spec                   ::prim/kilogram
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-kilogram
+     :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
+     :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-specific-heat
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    :gen                    impl/real-positive-double-generator
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
-    :json-schema/example    "0.2"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     :gen                    impl/real-positive-double-generator
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
+     :json-schema/example    "0.2"}))
 
 
 (spec/def ::top-up-water
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters."
-    :json-schema/example    "2.1"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added before fermentation in liters."
+     :json-schema/example    "2.1"}))
 
 
 (spec/def ::trub-chiller-loss
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel."
-    :json-schema/example    "0.1"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost during transition from the boiler to primary fermentation vessel."
+     :json-schema/example    "0.1"}))
 
 
 (spec/def ::evap-rate
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/percent
-    impl/display-name-key   "Evaporation Rate"
-    impl/beer-xml-type-key  impl/beer-xml-percentage
-    impl/beer-xml-units-key impl/beer-xml-percent-per-hour
-    :description            "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
-    :json-schema/example    "1.2"}))
+    {:type                   :double
+     :spec                   ::prim/percent
+     impl/display-name-key   "Evaporation Rate"
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     impl/beer-xml-units-key impl/beer-xml-percent-per-hour
+     :description            "A non-negative IEEE-754 floating point number representing the percentage of wort lost to evaporation per hour of the boil."
+     :json-schema/example    "1.2"}))
 
 
 (spec/def ::boil-time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            "A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss."
-    :json-schema/example    "15"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            "A non-negative IEEE-754 floating point number representing the normal amount of time one boils for this equipment setup. This can be used with the evaporation rate to calculate the evaporation loss."
+     :json-schema/example    "15"}))
 
 
 (spec/def ::calc-boil-volume
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/display-name-key  "Calculate Boil Volume"
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
-                                           "When absent, assume false."
-                                           "When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`")
-    :json-schema/example   "TRUE"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/display-name-key  "Calculate Boil Volume"
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline "A boolean denoting whether or not programs reading this equipment record should calculate the boil size."
+                                            "When absent, assume false."
+                                            "When true, then boil-size = `(batch-size - top-up-water - trub-chiller-loss) * (1 + boil-time * evap-rate)`")
+     :json-schema/example   "TRUE"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::lauter-deadspace
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun."
-    :json-schema/example    "0.1"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of wort lost to the lauter tun."
+     :json-schema/example    "0.1"}))
 
 
 (spec/def ::top-up-kettle
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins."
-    :json-schema/example    "2.1"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of top-up water added to the boil kettle before the boil begins."
+     :json-schema/example    "2.1"}))
 
 
 (spec/def ::hop-utilization
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization."
-    :json-schema/example   "1.2"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percentage of large batch hop utilization."
+     :json-schema/example   "1.2"}))
 
 
 (spec/def ::display-boil-size
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
-    :json-schema/example   "5.0 gallons"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
+     :json-schema/example   "5.0 gallons"}))
 
 
 (spec/def ::display-batch-size
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
-    :json-schema/example   "4.5 gallons"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
+     :json-schema/example   "4.5 gallons"}))
 
 
 (spec/def ::display-tun-volume
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units."
-    :json-schema/example   "20 liters"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the volume capacity of the mash tun formatted for display in arbitrary units."
+     :json-schema/example   "20 liters"}))
 
 
 (spec/def ::display-tun-weight
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units."
-    :json-schema/example   "5.5 pounds"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the empty weight of the mash tun formatted for display in arbitrary units."
+     :json-schema/example   "5.5 pounds"}))
 
 
 (spec/def ::display-top-up-water
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units."
-    :json-schema/example   "2.2 liters"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the volume of top-up water added before fermentation formatted for display in arbitrary units."
+     :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-trub-chiller-loss
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units."
-    :json-schema/example   "2.2 liters"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the volume of wort lost in transition between boiler and fermentation vessel formatted for display in arbitrary units."
+     :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-lauter-deadspace
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units."
-    :json-schema/example   "2.2 liters"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the volume of wort lost in the lauter vessel formatted for display in arbitrary units."
+     :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::display-top-up-kettle
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units."
-    :json-schema/example   "2.2 liters"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the top-up water added to the pre-boil stage of the kettle formatted for display in arbitrary units."
+     :json-schema/example   "2.2 liters"}))
 
 
 (spec/def ::equipment

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -174,152 +174,152 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  fermentable-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen fermentable-types)
-    :description           (impl/multiline "A case-sensitive string representing the form of the fermentable."
-                                           (impl/set->description fermentable-types)
-                                           ""
-                                           "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."
-                                           "- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley."
-                                           "- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form."
-                                           "- Grain: Whole or milled barley, rye, wheat, or other grain."
-                                           "- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)")
-    :json-schema/example   "grain"}))
+    {:type                  :string
+     :spec                  fermentable-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen fermentable-types)
+     :description           (impl/multiline "A case-sensitive string representing the form of the fermentable."
+                                            (impl/set->description fermentable-types)
+                                            ""
+                                            "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."
+                                            "- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley."
+                                            "- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form."
+                                            "- Grain: Whole or milled barley, rye, wheat, or other grain."
+                                            "- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)")
+     :json-schema/example   "grain"}))
 
 
 (spec/def ::yield
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable."
-    :json-schema/example   "0.856"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable."
+     :json-schema/example   "0.856"}))
 
 
 (spec/def ::color
   (st/spec
-   {:type                   :double
-    :spec                   number?
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key [impl/beer-xml-lovibond impl/beer-xml-srm]
-    :gen                    impl/real-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable."
-    :json-schema/example    "32"}))
+    {:type                   :double
+     :spec                   number?
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key [impl/beer-xml-lovibond impl/beer-xml-srm]
+     :gen                    impl/real-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable."
+     :json-schema/example    "32"}))
 
 
 (spec/def ::add-after-boil
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline "A boolean representing if the fermentable was added after the boil."
-                                           "When absent, assume false.")
-    :json-schema/example   "false"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline "A boolean representing if the fermentable was added after the boil."
+                                            "When absent, assume false.")
+     :json-schema/example   "false"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::supplier
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting the supplier of the fermentable ingredient."
-    :json-schema/example   "Gnome Brew"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the supplier of the fermentable ingredient."
+     :json-schema/example   "Gnome Brew"}))
 
 
 (spec/def ::coarse-fine-diff
   (st/spec
-   {:type                  :double
-    impl/display-name-key  "Coarse Fine Difference"
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :spec                  ::prim/percent
-    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
-                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
-    :json-schema/example   "0.856"}))
+    {:type                  :double
+     impl/display-name-key  "Coarse Fine Difference"
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :spec                  ::prim/percent
+     :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
+                                            "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example   "0.856"}))
 
 
 (spec/def ::moisture
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent moisture in the grain."
-                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
-    :json-schema/example   "45.0"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent moisture in the grain."
+                                            "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example   "45.0"}))
 
 
 (spec/def ::diastatic-power
   (st/spec
-   {:type                  :double
-    :spec                  number?
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-double-generator
-    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units."
-                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
-    :json-schema/example   "0.65"}))
+    {:type                  :double
+     :spec                  number?
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-double-generator
+     :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units."
+                                            "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example   "0.65"}))
 
 
 (spec/def ::protein
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the protein contents of the grain."
-                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
-    :json-schema/example   "10.0"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the protein contents of the grain."
+                                            "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example   "10.0"}))
 
 
 (spec/def ::max-in-batch
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables."
-    :json-schema/example   "1.0"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables."
+     :json-schema/example   "1.0"}))
 
 
 (spec/def ::recommend-mash
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline "A boolean representing if the fermentable is recommended to be included in the mashing step."
-                                           "Only appropriate for the 'Grain' or 'Adjunct' types."
-                                           "When absent, assume false.")
-    :json-schema/example   "false"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline "A boolean representing if the fermentable is recommended to be included in the mashing step."
+                                            "Only appropriate for the 'Grain' or 'Adjunct' types."
+                                            "When absent, assume false.")
+     :json-schema/example   "false"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::ibu-gal-per-lb
   (st/spec
-   {:type                  :double
-    :spec                  number?
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-double-generator
-    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil."
-                                           "Only appropriate for the 'Extract' type.")
-    :json-schema/example   "12.5"}))
+    {:type                  :double
+     :spec                  number?
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-double-generator
+     :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil."
+                                            "Only appropriate for the 'Extract' type.")
+     :json-schema/example   "12.5"}))
 
 
 (spec/def ::potential
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/specific-gravity
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-specific-gravity
-    :description            "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient."
-    :json-schema/example    "1.048"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :description            "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient."
+     :json-schema/example    "1.048"}))
 
 
 (spec/def ::display-color
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units."
-    :json-schema/example   "200 Lovibond"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units."
+     :json-schema/example   "200 Lovibond"}))
 
 
 (spec/def ::fermentable

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -2,7 +2,6 @@
   "The definition of a fermentable record used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -135,27 +134,27 @@
 
 (def adjunct
   "A non-grain and non-sugar ingredient that is added to the wort that contain fermentable sugars."
-  "adjunct")
+  "Adjunct")
 
 
 (def dry-extract
   "A concentrated form of fermentable sugars derived from malted barley."
-  "dry extract")
+  "Dry Extract")
 
 
 (def extract
   "A concentrated form of fermentable sugars derived from malted barley in liquid form."
-  "extract")
+  "Extract")
 
 
 (def grain
   "Whole or milled barley, rye, wheat, or other grain."
-  "grain")
+  "Grain")
 
 
 (def sugar
   "Raw, candied, and other natural sources of sugar (e.g. Honey)."
-  "sugar")
+  "Sugar")
 
 
 (def fermentable-types
@@ -176,11 +175,9 @@
 (spec/def ::type
   (st/spec
    {:type                :string
-    :spec                (spec/and string?
-                                   #(not (str/blank? %))
-                                   #(contains? fermentable-types (str/lower-case %)))
+    :spec                fermentable-types
     :gen                 #(spec/gen fermentable-types)
-    :description         (impl/multiline "A case-insensitive string representing the form of the fermentable."
+    :description         (impl/multiline "A case-sensitive string representing the form of the fermentable."
                                          (impl/set->description fermentable-types)
                                          ""
                                          "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -174,136 +174,152 @@
 
 (spec/def ::type
   (st/spec
-   {:type                :string
-    :spec                fermentable-types
-    :gen                 #(spec/gen fermentable-types)
-    :description         (impl/multiline "A case-sensitive string representing the form of the fermentable."
-                                         (impl/set->description fermentable-types)
-                                         ""
-                                         "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."
-                                         "- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley."
-                                         "- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form."
-                                         "- Grain: Whole or milled barley, rye, wheat, or other grain."
-                                         "- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)")
-    :json-schema/example "grain"}))
+   {:type                  :string
+    :spec                  fermentable-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen fermentable-types)
+    :description           (impl/multiline "A case-sensitive string representing the form of the fermentable."
+                                           (impl/set->description fermentable-types)
+                                           ""
+                                           "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."
+                                           "- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley."
+                                           "- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form."
+                                           "- Grain: Whole or milled barley, rye, wheat, or other grain."
+                                           "- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)")
+    :json-schema/example   "grain"}))
 
 
 (spec/def ::yield
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable."
-     :json-schema/example "0.856"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable."
+    :json-schema/example   "0.856"}))
 
 
 (spec/def ::color
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable."
-     :json-schema/example "32"}))
+   {:type                   :double
+    :spec                   number?
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key [impl/beer-xml-lovibond impl/beer-xml-srm]
+    :gen                    impl/real-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable."
+    :json-schema/example    "32"}))
 
 
 (spec/def ::add-after-boil
   (st/spec
-    {:spec                ::prim/boolean
-     :description         (impl/multiline "A boolean representing if the fermentable was added after the boil."
-                                          "When absent, assume false.")
-     :json-schema/example "false"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                  ::prim/boolean
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline "A boolean representing if the fermentable was added after the boil."
+                                           "When absent, assume false.")
+    :json-schema/example   "false"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::supplier
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the supplier of the fermentable ingredient."
-     :json-schema/example "Gnome Brew"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting the supplier of the fermentable ingredient."
+    :json-schema/example   "Gnome Brew"}))
 
 
 (spec/def ::coarse-fine-diff
   (st/spec
-    {:type                 :double
-     impl/display-name-key "Coarse Fine Difference"
-     :spec                 ::prim/percent
-     :description          (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
+   {:type                  :double
+    impl/display-name-key  "Coarse Fine Difference"
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :spec                  ::prim/percent
+    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
                                            "Only appropriate for the 'Grain' or 'Adjunct' types.")
-     :json-schema/example  "0.856"}))
+    :json-schema/example   "0.856"}))
 
 
 (spec/def ::moisture
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the percent moisture in the grain."
-                                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
-     :json-schema/example "0.45"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the percent moisture in the grain."
+                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
+    :json-schema/example   "45.0"}))
 
 
 (spec/def ::diastatic-power
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units."
-                                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
-     :json-schema/example "0.65"}))
+   {:type                  :double
+    :spec                  number?
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-double-generator
+    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the diastatic power of the grain in Lintner units."
+                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
+    :json-schema/example   "0.65"}))
 
 
 (spec/def ::protein
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the protein contents of the grain."
-                                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
-     :json-schema/example "0.10"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the protein contents of the grain."
+                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
+    :json-schema/example   "10.0"}))
 
 
 (spec/def ::max-in-batch
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables."
-     :json-schema/example "1.0"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the suggested maximum percent by weight of the fermentable with respect to all fermentables."
+    :json-schema/example   "1.0"}))
 
 
 (spec/def ::recommend-mash
   (st/spec
-    {:spec                ::prim/boolean
-     :description         (impl/multiline "A boolean representing if the fermentable is recommended to be included in the mashing step."
-                                          "Only appropriate for the 'Grain' or 'Adjunct' types."
-                                          "When absent, assume false.")
-     :json-schema/example "false"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                  ::prim/boolean
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline "A boolean representing if the fermentable is recommended to be included in the mashing step."
+                                           "Only appropriate for the 'Grain' or 'Adjunct' types."
+                                           "When absent, assume false.")
+    :json-schema/example   "false"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::ibu-gal-per-lb
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil."
-                                          "Only appropriate for the 'Extract' type.")
-     :json-schema/example "12.5"}))
+   {:type                  :double
+    :spec                  number?
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-double-generator
+    :description           (impl/multiline "A non-negative IEEE-754 floating point number representing the IBUs per pound per gallon of water assuming a 60 minute boil."
+                                           "Only appropriate for the 'Extract' type.")
+    :json-schema/example   "12.5"}))
 
 
 (spec/def ::potential
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient."
-     :json-schema/example "1.048"}))
+   {:type                   :double
+    :spec                   ::prim/specific-gravity
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-specific-gravity
+    :description            "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient."
+    :json-schema/example    "1.048"}))
 
 
 (spec/def ::display-color
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units."
-     :json-schema/example "200 Lovibond"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units."
+    :json-schema/example   "200 Lovibond"}))
 
 
 (spec/def ::fermentable
@@ -335,10 +351,11 @@
 
 (spec/def ::fermentable-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::fermentable` record wrapped in a `::fermentable` map."
-     :spec                 (spec/keys :req-un [::fermentable])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::fermentable` record wrapped in a `::fermentable` map."
+     :spec                  (spec/keys :req-un [::fermentable])}))
 
 
 (spec/def ::fermentables
@@ -352,7 +369,8 @@
 
 (spec/def ::fermentables-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::fermentables-wrapper` record."
-     :spec                 (spec/keys :req-un [::fermentables])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::fermentables-wrapper` record set."
+     :spec                  (spec/keys :req-un [::fermentables])}))

--- a/src/common_beer_format/fermentables.cljc
+++ b/src/common_beer_format/fermentables.cljc
@@ -31,10 +31,10 @@
 
 (def type
   "The type of the fermentable ingredient.
-   
+
    Currently, the following types are allowed:
 
-   - `adjunct` - Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars. 
+   - `adjunct` - Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars.
    - `dry-extract` - Dry extract is a concentrated form of fermentable sugars derived from malted barley.
    - `extract` - Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form.
    - `grain` - Whole or milled barley, rye, wheat, or other grain.
@@ -160,8 +160,8 @@
 
 (def fermentable-types
   "The types of fermentables that are allowed in BeerXML.
-   
-   - `adjunct` - Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars. 
+
+   - `adjunct` - Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars.
    - `dry-extract` - Dry extract is a concentrated form of fermentable sugars derived from malted barley.
    - `extract` - Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form.
    - `grain` - Whole or milled barley, rye, wheat, or other grain.
@@ -175,21 +175,27 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? fermentable-types (str/lower-case %)))
-     :gen                 #(spec/gen fermentable-types)
-     :description         (impl/multiline "A case-insensitive string representing the form of the fermentable."
-                                          (impl/set->description fermentable-types))
-     :json-schema/example "grain"}))
+   {:type                :string
+    :spec                (spec/and string?
+                                   #(not (str/blank? %))
+                                   #(contains? fermentable-types (str/lower-case %)))
+    :gen                 #(spec/gen fermentable-types)
+    :description         (impl/multiline "A case-insensitive string representing the form of the fermentable."
+                                         (impl/set->description fermentable-types)
+                                         ""
+                                         "- Adjunct: Non-grain and non-sugar ingredients that are added to the wort that contain fermentable sugars."
+                                         "- Dry Extract: Dry extract is a concentrated form of fermentable sugars derived from malted barley."
+                                         "- Extract: Extract is a concentrated form of fermentable sugars derived from malted barley in liquid form."
+                                         "- Grain: Whole or milled barley, rye, wheat, or other grain."
+                                         "- Sugar: Raw, candied, and other natural sources of sugar (e.g. Honey) .)")
+    :json-schema/example "grain"}))
 
 
 (spec/def ::yield
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable"
+     :description         "A non-negative IEEE-754 floating point number representing the percent rendered sugar from the fermentable."
      :json-schema/example "0.856"}))
 
 
@@ -198,7 +204,7 @@
     {:type                :double
      :spec                number?
      :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable"
+     :description         "A non-negative IEEE-754 floating point number representing the color in Lovibond for the grain type, and SRM for all other types for the fermentable."
      :json-schema/example "32"}))
 
 
@@ -216,17 +222,18 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the supplier of the fermentable ingredient"
+     :description         "A non-empty string denoting the supplier of the fermentable ingredient."
      :json-schema/example "Gnome Brew"}))
 
 
 (spec/def ::coarse-fine-diff
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
-                                          "Only appropriate for the 'Grain' or 'Adjunct' types.")
-     :json-schema/example "0.856"}))
+    {:type                 :double
+     impl/display-name-key "Coarse Fine Difference"
+     :spec                 ::prim/percent
+     :description          (impl/multiline "A non-negative IEEE-754 floating point number representing the percent difference between the coarse grain yield and fine grain yield."
+                                           "Only appropriate for the 'Grain' or 'Adjunct' types.")
+     :json-schema/example  "0.856"}))
 
 
 (spec/def ::moisture
@@ -290,7 +297,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient"
+     :description         "A non-negative IEEE-754 floating point number representing the potential yield in specific gravity units of the ingredient."
      :json-schema/example "1.048"}))
 
 
@@ -298,7 +305,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the color of the ingredient formatted for display in arbitrary units."
      :json-schema/example "200 Lovibond"}))
 
 
@@ -331,15 +338,16 @@
 
 (spec/def ::fermentable-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::fermentable record wrapped in a ::fermentable map"
-     :spec        (spec/keys :req-un [::fermentable])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::fermentable` record wrapped in a `::fermentable` map."
+     :spec                 (spec/keys :req-un [::fermentable])}))
 
 
 (spec/def ::fermentables
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::fermentable-wrapper records"
+     :description   "A vector of valid `::fermentable-wrapper` records."
      :spec          (spec/coll-of ::fermentable-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::fermentable-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::fermentable-wrapper %2)}))
@@ -347,6 +355,7 @@
 
 (spec/def ::fermentables-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::fermentables-wrapper record"
-     :spec        (spec/keys :req-un [::fermentables])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::fermentables-wrapper` record."
+     :spec                 (spec/keys :req-un [::fermentables])}))

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -2,7 +2,6 @@
   "The definition of a hop record used in BeerXML"
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -149,27 +148,27 @@
 
 (def boil
   "Hops added to the boil."
-  "boil")
+  "Boil")
 
 
 (def dry-hop
   "Hops added to the fermentation vessel after pitching yeast."
-  "dry hop")
+  "Dry Hop")
 
 
 (def mash
   "Hops added to the mash prior to the boil."
-  "mash")
+  "Mash")
 
 
 (def first-wort
   "Hops added to the first wort."
-  "first wort")
+  "First Wort")
 
 
 (def aroma
   "Hops added to the beer for aroma."
-  "aroma")
+  "Aroma")
 
 
 (def hop-uses
@@ -184,11 +183,9 @@
 (spec/def ::use
   (st/spec
     {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? hop-uses (str/lower-case %)))
+     :spec                hop-uses
      :gen                 #(spec/gen hop-uses)
-     :description         (impl/multiline "A case-insensitive string representing the means by which the hop is added to the beer."
+     :description         (impl/multiline "A case-sensitive string representing the means by which the hop is added to the beer."
                                           (impl/set->description hop-uses)
                                           ""
                                           "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
@@ -216,12 +213,12 @@
 
 (def bittering
   "Hops added to the boil for bittering."
-  "bittering")
+  "Bittering")
 
 
 (def both
   "Hops added to the boil for both bittering and aroma."
-  "both")
+  "Both")
 
 
 (def hop-types
@@ -234,11 +231,9 @@
 (spec/def ::type
   (st/spec
     {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? hop-types (str/lower-case %)))
+     :spec                hop-types
      :gen                 #(spec/gen hop-types)
-     :description         (impl/multiline "A case-insensitive string representing the typical purpose of the hop's addition to a beer."
+     :description         (impl/multiline "A case-sensitive string representing the typical purpose of the hop's addition to a beer."
                                           (impl/set->description hop-types)
                                           ""
                                           "- Bittering: Hops added solely for their bittering properties."
@@ -249,17 +244,17 @@
 
 (def pellet
   "Hops added to the boil in pellet form."
-  "pellet")
+  "Pellet")
 
 
 (def plug
   "Hops added to the boil in plug form."
-  "plug")
+  "Plug")
 
 
 (def leaf
   "Hops added to the boil in whole leaf form."
-  "leaf")
+  "Leaf")
 
 
 (def hop-forms
@@ -272,11 +267,9 @@
 (spec/def ::form
   (st/spec
     {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? hop-forms (str/lower-case %)))
+     :spec                hop-forms
      :gen                 #(spec/gen hop-forms)
-     :description         (impl/multiline "A case-insensitive string representing the physical form of the hop."
+     :description         (impl/multiline "A case-sensitive string representing the physical form of the hop."
                                           (impl/set->description hop-forms)
                                           ""
                                           "- Pellet: Ground and compressed hop cones."

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -354,7 +354,7 @@
 (spec/def ::hops
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::hop records"
+     :description   "A vector of valid ::hop-wrapper records"
      :spec          (spec/coll-of ::hop-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::hop-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::hop-wrapper %2)}))

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -140,11 +140,11 @@
 
 (spec/def ::alpha
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (def boil
@@ -183,36 +183,36 @@
 
 (spec/def ::use
   (st/spec
-   {:type                  :string
-    :spec                  hop-uses
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen hop-uses)
-    :description           (impl/multiline "A case-sensitive string representing the means by which the hop is added to the beer."
-                                           (impl/set->description hop-uses)
-                                           ""
-                                           "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
-                                           "- Boil: Hops added to the boil for bittering."
-                                           "- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer."
-                                           "- First Wort: Hops added to first wort prior to the boil."
-                                           "- Mash: Hops added to the mash prior to the boil.")
-    :json-schema/example   "mash"}))
+    {:type                  :string
+     :spec                  hop-uses
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen hop-uses)
+     :description           (impl/multiline "A case-sensitive string representing the means by which the hop is added to the beer."
+                                            (impl/set->description hop-uses)
+                                            ""
+                                            "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
+                                            "- Boil: Hops added to the boil for bittering."
+                                            "- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer."
+                                            "- First Wort: Hops added to first wort prior to the boil."
+                                            "- Mash: Hops added to the mash prior to the boil.")
+     :json-schema/example   "mash"}))
 
 
 (spec/def ::time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            (impl/multiline
-                             "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the `:use` field."
-                             ""
-                             "- Boil: this is the boil time."
-                             "- Mash: this is the mash time."
-                             "- First Wort: this is the boil time."
-                             "- Aroma: this is the steep time."
-                             "- Dry Hop: this is the amount of time to dry hop.")
-    :json-schema/example    "15.0"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            (impl/multiline
+                               "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the `:use` field."
+                               ""
+                               "- Boil: this is the boil time."
+                               "- Mash: this is the mash time."
+                               "- First Wort: this is the boil time."
+                               "- Aroma: this is the steep time."
+                               "- Dry Hop: this is the amount of time to dry hop.")
+     :json-schema/example    "15.0"}))
 
 
 (def bittering
@@ -234,17 +234,17 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  hop-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen hop-types)
-    :description           (impl/multiline "A case-sensitive string representing the typical purpose of the hop's addition to a beer."
-                                           (impl/set->description hop-types)
-                                           ""
-                                           "- Bittering: Hops added solely for their bittering properties."
-                                           "- Aroma: Hops added solely for their aromatic properties and flavor."
-                                           "- Both: Hops which may be added for both/either their bittering and/or aromatic properties.")
-    :json-schema/example   "bittering"}))
+    {:type                  :string
+     :spec                  hop-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen hop-types)
+     :description           (impl/multiline "A case-sensitive string representing the typical purpose of the hop's addition to a beer."
+                                            (impl/set->description hop-types)
+                                            ""
+                                            "- Bittering: Hops added solely for their bittering properties."
+                                            "- Aroma: Hops added solely for their aromatic properties and flavor."
+                                            "- Both: Hops which may be added for both/either their bittering and/or aromatic properties.")
+     :json-schema/example   "bittering"}))
 
 
 (def pellet
@@ -271,72 +271,72 @@
 
 (spec/def ::form
   (st/spec
-   {:type                  :string
-    :spec                  hop-forms
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen hop-forms)
-    :description           (impl/multiline "A case-sensitive string representing the physical form of the hop."
-                                           (impl/set->description hop-forms)
-                                           ""
-                                           "- Pellet: Ground and compressed hop cones."
-                                           "- Plug: Whole hop cones compressed into plugs."
-                                           "- Leaf: Whole hop cones.")
-    :json-schema/example   "leaf"}))
+    {:type                  :string
+     :spec                  hop-forms
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen hop-forms)
+     :description           (impl/multiline "A case-sensitive string representing the physical form of the hop."
+                                            (impl/set->description hop-forms)
+                                            ""
+                                            "- Pellet: Ground and compressed hop cones."
+                                            "- Plug: Whole hop cones compressed into plugs."
+                                            "- Leaf: Whole hop cones.")
+     :json-schema/example   "leaf"}))
 
 
 (spec/def ::beta
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::hsi
   (st/spec
-   {:type                  :double
-    impl/display-name-key  "Hop Stability Index"
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :spec                  ::prim/percent
-    :description           "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months."
-    :json-schema/example   "2.2"}))
+    {:type                  :double
+     impl/display-name-key  "Hop Stability Index"
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :spec                  ::prim/percent
+     :description           "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months."
+     :json-schema/example   "2.2"}))
 
 
 (spec/def ::humulene
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::caryophyllene
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::cohumulone
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::myrcene
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::hop

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -143,7 +143,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop."
      :json-schema/example "10.7"}))
 
 
@@ -189,22 +189,29 @@
                                     #(contains? hop-uses (str/lower-case %)))
      :gen                 #(spec/gen hop-uses)
      :description         (impl/multiline "A case-insensitive string representing the means by which the hop is added to the beer."
-                                          (impl/set->description hop-uses))
+                                          (impl/set->description hop-uses)
+                                          ""
+                                          "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
+                                          "- Boil: Hops added to the boil for bittering."
+                                          "- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer."
+                                          "- First Wort: Hops added to first wort prior to the boil."
+                                          "- Mash: Hops added to the mash prior to the boil.")
      :json-schema/example "mash"}))
 
 
 (spec/def ::time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         (impl/multiline
-                            "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
-                            "For \"Boil\" this is the boil time."
-                            "For \"Mash\" this is the mash time."
-                            "For \"First Wort\" this is the boil time."
-                            "For \"Aroma\" this is the steep time."
-                            "For \"Dry Hop\" this is the amount of time to dry hop.")
-     :json-schema/example "15.0"}))
+   {:type                :double
+    :spec                ::prim/minute
+    :description         (impl/multiline
+                          "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
+                          ""
+                          "- Boil: this is the boil time."
+                          "- Mash: this is the mash time."
+                          "- First Wort: this is the boil time."
+                          "- Aroma: this is the steep time."
+                          "- Dry Hop: this is the amount of time to dry hop.")
+    :json-schema/example "15.0"}))
 
 
 (def bittering
@@ -231,8 +238,12 @@
                                     #(not (str/blank? %))
                                     #(contains? hop-types (str/lower-case %)))
      :gen                 #(spec/gen hop-types)
-     :description         (impl/multiline "A case-insensitive string representing the means by which the hop is added to the beer."
-                                          (impl/set->description hop-types))
+     :description         (impl/multiline "A case-insensitive string representing the typical purpose of the hop's addition to a beer."
+                                          (impl/set->description hop-types)
+                                          ""
+                                          "- Bittering: Hops added solely for their bittering properties."
+                                          "- Aroma: Hops added solely for their aromatic properties and flavor."
+                                          "- Both: Hops which may be added for both/either their bittering and/or aromatic properties.")
      :json-schema/example "bittering"}))
 
 
@@ -266,7 +277,11 @@
                                     #(contains? hop-forms (str/lower-case %)))
      :gen                 #(spec/gen hop-forms)
      :description         (impl/multiline "A case-insensitive string representing the physical form of the hop."
-                                          (impl/set->description hop-forms))
+                                          (impl/set->description hop-forms)
+                                          ""
+                                          "- Pellet: Ground and compressed hop cones."
+                                          "- Plug: Whole hop cones compressed into plugs."
+                                          "- Leaf: Whole hop cones.")
      :json-schema/example "leaf"}))
 
 
@@ -274,23 +289,24 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop."
      :json-schema/example "10.7"}))
 
 
 (spec/def ::hsi
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months"
-     :json-schema/example "2.2"}))
+    {:type                 :double
+     impl/display-name-key "Hop Stability Index"
+     :spec                 ::prim/percent
+     :description          "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months."
+     :json-schema/example  "2.2"}))
 
 
 (spec/def ::humulene
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop."
      :json-schema/example "10.7"}))
 
 
@@ -298,7 +314,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop."
      :json-schema/example "10.7"}))
 
 
@@ -306,7 +322,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop."
      :json-schema/example "10.7"}))
 
 
@@ -314,7 +330,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop"
+     :description         "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop."
      :json-schema/example "10.7"}))
 
 
@@ -346,15 +362,16 @@
 
 (spec/def ::hop-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::hop record wrapped in a ::hop map"
-     :spec        (spec/keys :req-un [::hop])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::hop` record wrapped in a `:hop` map."
+     :spec                 (spec/keys :req-un [::hop])}))
 
 
 (spec/def ::hops
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::hop-wrapper records"
+     :description   "A vector of valid `::hop-wrapper` records."
      :spec          (spec/coll-of ::hop-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::hop-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::hop-wrapper %2)}))
@@ -362,6 +379,7 @@
 
 (spec/def ::hops-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::hops-wrapper record"
-     :spec        (spec/keys :req-un [::hops])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::hops-wrapper` record."
+     :spec                 (spec/keys :req-un [::hops])}))

--- a/src/common_beer_format/hops.cljc
+++ b/src/common_beer_format/hops.cljc
@@ -140,10 +140,11 @@
 
 (spec/def ::alpha
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of alpha acid in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (def boil
@@ -182,33 +183,36 @@
 
 (spec/def ::use
   (st/spec
-    {:type                :string
-     :spec                hop-uses
-     :gen                 #(spec/gen hop-uses)
-     :description         (impl/multiline "A case-sensitive string representing the means by which the hop is added to the beer."
-                                          (impl/set->description hop-uses)
-                                          ""
-                                          "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
-                                          "- Boil: Hops added to the boil for bittering."
-                                          "- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer."
-                                          "- First Wort: Hops added to first wort prior to the boil."
-                                          "- Mash: Hops added to the mash prior to the boil.")
-     :json-schema/example "mash"}))
+   {:type                  :string
+    :spec                  hop-uses
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen hop-uses)
+    :description           (impl/multiline "A case-sensitive string representing the means by which the hop is added to the beer."
+                                           (impl/set->description hop-uses)
+                                           ""
+                                           "- Aroma: Hops added to the beer after the boil. They do not significantly contribute to the bitterness of the beer."
+                                           "- Boil: Hops added to the boil for bittering."
+                                           "- Dry Hop: Hops added to the fermentation vessel after pitching yeast. They do not significantly contribute to the bitterness of the beer."
+                                           "- First Wort: Hops added to first wort prior to the boil."
+                                           "- Mash: Hops added to the mash prior to the boil.")
+    :json-schema/example   "mash"}))
 
 
 (spec/def ::time
   (st/spec
-   {:type                :double
-    :spec                ::prim/minute
-    :description         (impl/multiline
-                          "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the :use field."
-                          ""
-                          "- Boil: this is the boil time."
-                          "- Mash: this is the mash time."
-                          "- First Wort: this is the boil time."
-                          "- Aroma: this is the steep time."
-                          "- Dry Hop: this is the amount of time to dry hop.")
-    :json-schema/example "15.0"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            (impl/multiline
+                             "A non-negative IEEE-754 floating point number representing the time in minutes the hop was added dependant on the `:use` field."
+                             ""
+                             "- Boil: this is the boil time."
+                             "- Mash: this is the mash time."
+                             "- First Wort: this is the boil time."
+                             "- Aroma: this is the steep time."
+                             "- Dry Hop: this is the amount of time to dry hop.")
+    :json-schema/example    "15.0"}))
 
 
 (def bittering
@@ -230,16 +234,17 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                hop-types
-     :gen                 #(spec/gen hop-types)
-     :description         (impl/multiline "A case-sensitive string representing the typical purpose of the hop's addition to a beer."
-                                          (impl/set->description hop-types)
-                                          ""
-                                          "- Bittering: Hops added solely for their bittering properties."
-                                          "- Aroma: Hops added solely for their aromatic properties and flavor."
-                                          "- Both: Hops which may be added for both/either their bittering and/or aromatic properties.")
-     :json-schema/example "bittering"}))
+   {:type                  :string
+    :spec                  hop-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen hop-types)
+    :description           (impl/multiline "A case-sensitive string representing the typical purpose of the hop's addition to a beer."
+                                           (impl/set->description hop-types)
+                                           ""
+                                           "- Bittering: Hops added solely for their bittering properties."
+                                           "- Aroma: Hops added solely for their aromatic properties and flavor."
+                                           "- Both: Hops which may be added for both/either their bittering and/or aromatic properties.")
+    :json-schema/example   "bittering"}))
 
 
 (def pellet
@@ -266,65 +271,72 @@
 
 (spec/def ::form
   (st/spec
-    {:type                :string
-     :spec                hop-forms
-     :gen                 #(spec/gen hop-forms)
-     :description         (impl/multiline "A case-sensitive string representing the physical form of the hop."
-                                          (impl/set->description hop-forms)
-                                          ""
-                                          "- Pellet: Ground and compressed hop cones."
-                                          "- Plug: Whole hop cones compressed into plugs."
-                                          "- Leaf: Whole hop cones.")
-     :json-schema/example "leaf"}))
+   {:type                  :string
+    :spec                  hop-forms
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen hop-forms)
+    :description           (impl/multiline "A case-sensitive string representing the physical form of the hop."
+                                           (impl/set->description hop-forms)
+                                           ""
+                                           "- Pellet: Ground and compressed hop cones."
+                                           "- Plug: Whole hop cones compressed into plugs."
+                                           "- Leaf: Whole hop cones.")
+    :json-schema/example   "leaf"}))
 
 
 (spec/def ::beta
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of beta acid in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (spec/def ::hsi
   (st/spec
-    {:type                 :double
-     impl/display-name-key "Hop Stability Index"
-     :spec                 ::prim/percent
-     :description          "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months."
-     :json-schema/example  "2.2"}))
+   {:type                  :double
+    impl/display-name-key  "Hop Stability Index"
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :spec                  ::prim/percent
+    :description           "A non-negative IEEE-754 floating point number representing the Hop Stability Index, or percent decay of a hop's alpha acid over six months."
+    :json-schema/example   "2.2"}))
 
 
 (spec/def ::humulene
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of humulene in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (spec/def ::caryophyllene
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of caryophyllene in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (spec/def ::cohumulone
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of cohumulone in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (spec/def ::myrcene
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop."
-     :json-schema/example "10.7"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent contents of myrcene in the hop."
+    :json-schema/example   "10.7"}))
 
 
 (spec/def ::hop
@@ -355,10 +367,11 @@
 
 (spec/def ::hop-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::hop` record wrapped in a `:hop` map."
-     :spec                 (spec/keys :req-un [::hop])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::hop` record wrapped in a `:hop` map."
+     :spec                  (spec/keys :req-un [::hop])}))
 
 
 (spec/def ::hops
@@ -372,7 +385,8 @@
 
 (spec/def ::hops-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::hops-wrapper` record."
-     :spec                 (spec/keys :req-un [::hops])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::hops-wrapper` record set."
+     :spec                  (spec/keys :req-un [::hops])}))

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -1,8 +1,9 @@
-(ns ^:no-doc common-beer-format.impl
+(ns common-beer-format.impl
   "Utility functions common to translation.
-   
+
    This namespace is not intended to be used directly."
-  {:added "1.0"}
+  {:added  "1.0"
+   :no-doc true}
   (:require [clojure.string :as str]
             [clojure.test.check.generators :as gen]
             [nnichols.parse :as n-parse]
@@ -90,7 +91,7 @@
 
 (defn multiline
   "Concatenate all strings together, with a new line between each.
-   
+
    When no arguments are provided, returns an empty string.
    When only one argument is provided, returns that argument."
   {:added  "1.0"

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -98,7 +98,11 @@
    :no-doc true}
   ([] "")
   ([s] s)
-  ([s & more] (str s "\n" (apply multiline more))))
+  ([s & more]
+
+   (if s
+    (str s "\n" (apply multiline more))
+    (apply multiline more))))
 
 
 (defn real-double-generator
@@ -130,6 +134,131 @@
 (def display-name-key
   "A keyword intended for use with spec-tools to indicate a display name for a spec."
   :common-beer-format/display-name)
+
+(def beer-xml-type-key
+  "A keyword intended for use with spec-tools to indicate the type of a beer-xml spec."
+  :common-beer-format/beer-xml-type)
+
+(def beer-xml-record-set
+  "The BeerXML version 1 type for a record set."
+  "Record Set")
+
+(def beer-xml-record
+  "The BeerXML version 1 type for a record."
+  "Record")
+
+(def beer-xml-percentage
+  "The BeerXML version 1 type for a percentage."
+  "Percentage")
+
+(def beer-xml-list
+  "The BeerXML version 1 type for a list."
+  "List")
+
+(def beer-xml-text
+  "The BeerXML version 1 type for a text."
+  "Text")
+
+(def beer-xml-boolean
+  "The BeerXML version 1 type for a boolean."
+  "Boolean")
+
+(def beer-xml-integer
+  "The BeerXML version 1 type for an integer."
+  "Integer")
+
+(def beer-xml-floating-point
+  "The BeerXML version 1 type for a floating point number."
+  "Floating Point")
+
+(def beer-xml-types
+  "A set of all BeerXML version 1 types.
+   These are called Dara Formats in the BeerXML standard."
+  #{beer-xml-record-set
+    beer-xml-record
+    beer-xml-percentage
+    beer-xml-list
+    beer-xml-text
+    beer-xml-boolean
+    beer-xml-integer
+    beer-xml-floating-point})
+
+(def beer-xml-units-key
+  "A keyword intended for use with spec-tools to indicate the unit of a beer-xml spec."
+  :common-beer-format/beer-xml-units)
+
+(def beer-xml-kilogram
+  "The BeerXML version 1 unit for a kilogram."
+  "Kilogram")
+
+(def beer-xml-liter
+  "The BeerXML version 1 unit for a liter."
+  "Liter")
+
+(def beer-xml-degrees-celsius
+  "The BeerXML version 1 unit for degrees Celsius."
+  "Degrees Celsius")
+
+(def beer-xml-minute
+  "The BeerXML version 1 unit for a minute."
+  "Minute")
+
+(def beer-xml-day
+  "The BeerXML version 1 unit for a day."
+  "Day")
+
+(def beer-xml-specific-gravity
+  "The BeerXML version 1 unit for specific gravity."
+  "Specific Gravity")
+
+(def beer-xml-kilopascal
+  "The BeerXML version 1 unit for a kilopascal."
+  "Kilopascal")
+
+(def beer-xml-abv
+  "The BeerXML version 1 unit for ABV."
+  "ABV")
+
+(def beer-xml-ibu
+  "The BeerXML version 1 unit for IBU."
+  "IBU")
+
+(def beer-xml-volumes-of-co2
+  "The BeerXML version 1 unit for volumes of CO2."
+  "Volumes of CO2")
+
+(def beer-xml-calories-per-gram-degree-celsius
+  "The BeerXML version 1 unit for calories per gram degree Celsius."
+  "Calories per Gram Degree Celsius")
+
+(def beer-xml-percent-per-hour
+  "The BeerXML version 1 unit for percent per hour."
+  "Percent per Hour")
+
+(def beer-xml-srm
+  "The BeerXML version 1 unit for SRM."
+  "SRM")
+
+(def beer-xml-lovibond
+  "The BeerXML version 1 unit for Lovibond."
+  "Lovibond")
+
+(def beer-xml-units
+  "A set of all BeerXML version 1 units."
+  #{beer-xml-kilogram
+    beer-xml-liter
+    beer-xml-degrees-celsius
+    beer-xml-minute
+    beer-xml-day
+    beer-xml-specific-gravity
+    beer-xml-kilopascal
+    beer-xml-abv
+    beer-xml-ibu
+    beer-xml-volumes-of-co2
+    beer-xml-calories-per-gram-degree-celsius
+    beer-xml-percent-per-hour
+    beer-xml-srm
+    beer-xml-lovibond})
 
 
 (defn wrapper-spec?

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -123,13 +123,16 @@
                 :NaN?      false
                 :min       0}))
 
+
 (def wrapper-spec-key
   "A keyword intended for use with spec-tools to indicate a spec for a wrapper type."
   :common-beer-format/wrapper?)
 
+
 (def display-name-key
   "A keyword intended for use with spec-tools to indicate a display name for a spec."
   :common-beer-format/display-name)
+
 
 (defn wrapper-spec?
   "Check if a spec is a wrapper spec."
@@ -137,6 +140,7 @@
    :no-doc true}
   [spec]
   (-> spec st/get-spec (get wrapper-spec-key false)))
+
 
 (defn spec->display-name
   "Get the display name of a spec."

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -7,7 +7,9 @@
   (:require [clojure.string :as str]
             [clojure.test.check.generators :as gen]
             [nnichols.parse :as n-parse]
-            [spec-tools.core :as st]))
+            [spec-tools.core :as st]
+            [clojure.spec.alpha :as spec]
+            [clojure.test :as t]))
 
 
 (def strict-transformer
@@ -120,3 +122,25 @@
   (gen/double* {:infinite? false
                 :NaN?      false
                 :min       0}))
+
+(def wrapper-spec-key
+  "A keyword intended for use with spec-tools to indicate a spec for a wrapper type."
+  :common-beer-format/wrapper?)
+
+(def display-name-key
+  "A keyword intended for use with spec-tools to indicate a display name for a spec."
+  :common-beer-format/display-name)
+
+(defn wrapper-spec?
+  "Check if a spec is a wrapper spec."
+  {:added  "2.3"
+   :no-doc true}
+  [spec]
+  (-> spec st/get-spec (get wrapper-spec-key false)))
+
+(defn spec->display-name
+  "Get the display name of a spec."
+  {:added  "2.3"
+   :no-doc true}
+  [spec]
+  (-> spec st/get-spec (get display-name-key)))

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -100,8 +100,8 @@
   ([s] s)
   ([s & more]
    (if s
-    (str s "\n" (apply multiline more))
-    (apply multiline more))))
+     (str s "\n" (apply multiline more))
+     (apply multiline more))))
 
 
 (defn real-double-generator
@@ -134,41 +134,51 @@
   "A keyword intended for use with spec-tools to indicate a display name for a spec."
   :common-beer-format/display-name)
 
+
 (def beer-xml-type-key
   "A keyword intended for use with spec-tools to indicate the type of a beer-xml spec."
   :common-beer-format/beer-xml-type)
+
 
 (def beer-xml-record-set
   "The BeerXML version 1 type for a record set."
   "Record Set")
 
+
 (def beer-xml-record
   "The BeerXML version 1 type for a record."
   "Record")
+
 
 (def beer-xml-percentage
   "The BeerXML version 1 type for a percentage."
   "Percentage")
 
+
 (def beer-xml-list
   "The BeerXML version 1 type for a list."
   "List")
+
 
 (def beer-xml-text
   "The BeerXML version 1 type for a text."
   "Text")
 
+
 (def beer-xml-boolean
   "The BeerXML version 1 type for a boolean."
   "Boolean")
+
 
 (def beer-xml-integer
   "The BeerXML version 1 type for an integer."
   "Integer")
 
+
 (def beer-xml-floating-point
   "The BeerXML version 1 type for a floating point number."
   "Floating Point")
+
 
 (def beer-xml-types
   "A set of all BeerXML version 1 types.
@@ -182,65 +192,81 @@
     beer-xml-integer
     beer-xml-floating-point})
 
+
 (def beer-xml-units-key
   "A keyword intended for use with spec-tools to indicate the unit of a beer-xml spec."
   :common-beer-format/beer-xml-units)
+
 
 (def beer-xml-kilogram
   "The BeerXML version 1 unit for a kilogram."
   "Kilogram")
 
+
 (def beer-xml-liter
   "The BeerXML version 1 unit for a liter."
   "Liter")
+
 
 (def beer-xml-degrees-celsius
   "The BeerXML version 1 unit for degrees Celsius."
   "Degrees Celsius")
 
+
 (def beer-xml-minute
   "The BeerXML version 1 unit for a minute."
   "Minute")
+
 
 (def beer-xml-day
   "The BeerXML version 1 unit for a day."
   "Day")
 
+
 (def beer-xml-specific-gravity
   "The BeerXML version 1 unit for specific gravity."
   "Specific Gravity")
+
 
 (def beer-xml-kilopascal
   "The BeerXML version 1 unit for a kilopascal."
   "Kilopascal")
 
+
 (def beer-xml-abv
   "The BeerXML version 1 unit for ABV."
   "ABV")
+
 
 (def beer-xml-ibu
   "The BeerXML version 1 unit for IBU."
   "IBU")
 
+
 (def beer-xml-volumes-of-co2
   "The BeerXML version 1 unit for volumes of CO2."
   "Volumes of CO2")
+
 
 (def beer-xml-calories-per-gram-degree-celsius
   "The BeerXML version 1 unit for calories per gram degree Celsius."
   "Calories per Gram Degree Celsius")
 
+
 (def beer-xml-percent-per-hour
   "The BeerXML version 1 unit for percent per hour."
   "Percent per Hour")
+
 
 (def beer-xml-srm
   "The BeerXML version 1 unit for SRM."
   "SRM")
 
+
 (def beer-xml-lovibond
   "The BeerXML version 1 unit for Lovibond."
   "Lovibond")
+
 
 (def beer-xml-units
   "A set of all BeerXML version 1 units."

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -99,7 +99,6 @@
   ([] "")
   ([s] s)
   ([s & more]
-
    (if s
     (str s "\n" (apply multiline more))
     (apply multiline more))))

--- a/src/common_beer_format/impl.cljc
+++ b/src/common_beer_format/impl.cljc
@@ -7,9 +7,7 @@
   (:require [clojure.string :as str]
             [clojure.test.check.generators :as gen]
             [nnichols.parse :as n-parse]
-            [spec-tools.core :as st]
-            [clojure.spec.alpha :as spec]
-            [clojure.test :as t]))
+            [spec-tools.core :as st]))
 
 
 (def strict-transformer

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -124,127 +124,127 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  mash-step-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen mash-step-types)
-    :description           (impl/multiline "A case-sensitive string representing the type of mash step."
-                                           (impl/set->description mash-step-types)
-                                           ""
-                                           "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
-                                           "- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature."
-                                           "- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.")
-    :json-schema/example   "Temperature"}))
+    {:type                  :string
+     :spec                  mash-step-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen mash-step-types)
+     :description           (impl/multiline "A case-sensitive string representing the type of mash step."
+                                            (impl/set->description mash-step-types)
+                                            ""
+                                            "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
+                                            "- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature."
+                                            "- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.")
+     :json-schema/example   "Temperature"}))
 
 
 (spec/def ::infuse-amount
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step."
-    :json-schema/example    "5.8"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step."
+     :json-schema/example    "5.8"}))
 
 
 (spec/def ::step-temp
   (st/spec
-   {:type                   :double
-    impl/display-name-key   "Step Temperature"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :spec                   ::prim/degrees-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius."
-    :json-schema/example    "80"}))
+    {:type                   :double
+     impl/display-name-key   "Step Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :spec                   ::prim/degrees-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius."
+     :json-schema/example    "80"}))
 
 
 (spec/def ::step-time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step."
-    :json-schema/example    "45.0"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step."
+     :json-schema/example    "45.0"}))
 
 
 (spec/def ::ramp-time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature."
-    :json-schema/example    "45.0"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature."
+     :json-schema/example    "45.0"}))
 
 
 (spec/def ::end-temp
   (st/spec
-   {:type                   :double
-    impl/display-name-key   "End Temperature"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :spec                   ::prim/degrees-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius."
-    :json-schema/example    "80"}))
+    {:type                   :double
+     impl/display-name-key   "End Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :spec                   ::prim/degrees-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius."
+     :json-schema/example    "80"}))
 
 
 (spec/def ::description
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string describing the mash step."
-    :json-schema/example   "Stir your grain bag carefully at 140F."}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string describing the mash step."
+     :json-schema/example   "Stir your grain bag carefully at 140F."}))
 
 
 (spec/def ::water-grain-ratio
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units."
-    :json-schema/example   "1.5qt/lb"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units."
+     :json-schema/example   "1.5qt/lb"}))
 
 
 (spec/def ::decoction-amt
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Decoction Amount"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
-    :json-schema/example   "7.5 liters"}))
+    {:type                  :string
+     impl/display-name-key  "Decoction Amount"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
+     :json-schema/example   "7.5 liters"}))
 
 
 (spec/def ::infuse-temp
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Infusion Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units."
-    :json-schema/example   "150F"}))
+    {:type                  :string
+     impl/display-name-key  "Infusion Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units."
+     :json-schema/example   "150F"}))
 
 
 (spec/def ::display-step-temp
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Display Step Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units."
-    :json-schema/example   "150F"}))
+    {:type                  :string
+     impl/display-name-key  "Display Step Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units."
+     :json-schema/example   "150F"}))
 
 
 (spec/def ::display-infuse-amt
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Display Infusion Amount"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units."
-    :json-schema/example   "2.2L"}))
+    {:type                  :string
+     impl/display-name-key  "Display Infusion Amount"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units."
+     :json-schema/example   "2.2L"}))
 
 
 (spec/def ::mash-step
@@ -353,116 +353,116 @@
 
 (spec/def ::grain-temp
   (st/spec
-   {:type                   :double
-    impl/display-name-key   "Grain Temperature"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :spec                   ::prim/degrees-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius."
-    :json-schema/example    "80"}))
+    {:type                   :double
+     impl/display-name-key   "Grain Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :spec                   ::prim/degrees-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius."
+     :json-schema/example    "80"}))
 
 
 (spec/def ::tun-temp
   (st/spec
-   {:type                   :double
-    impl/display-name-key   "Tun Temperature"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :spec                   ::prim/degrees-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius."
-    :json-schema/example    "80"}))
+    {:type                   :double
+     impl/display-name-key   "Tun Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :spec                   ::prim/degrees-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius."
+     :json-schema/example    "80"}))
 
 
 (spec/def ::sparge-temp
   (st/spec
-   {:type                   :double
-    impl/display-name-key   "Sparge Temperature"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :spec                   ::prim/degrees-celsius
-    :description            "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius."
-    :json-schema/example    "50"}))
+    {:type                   :double
+     impl/display-name-key   "Sparge Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :spec                   ::prim/degrees-celsius
+     :description            "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius."
+     :json-schema/example    "50"}))
 
 
 (spec/def ::ph
   (st/spec
-   {:type                  :double
-    impl/display-name-key  "PH"
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :spec                  ::prim/non-negative-number
-    :description           "A non-negative IEEE-754 floating point number representing the PH of the water."
-    :json-schema/example   "2.5"}))
+    {:type                  :double
+     impl/display-name-key  "PH"
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :spec                  ::prim/non-negative-number
+     :description           "A non-negative IEEE-754 floating point number representing the PH of the water."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::tun-weight
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/kilogram
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-kilogram
-    :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
-    :json-schema/example    "15.0"}))
+    {:type                   :double
+     :spec                   ::prim/kilogram
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-kilogram
+     :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
+     :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-specific-heat
   (st/spec
-   {:type                   :double
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
-    :spec                   ::prim/non-negative-number
-    :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
-    :json-schema/example    "0.2"}))
+    {:type                   :double
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
+     :spec                   ::prim/non-negative-number
+     :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
+     :json-schema/example    "0.2"}))
 
 
 (spec/def ::equip-adjust
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/display-name-key  "Equipment Adjust"
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline "A boolean denoting whether or not programs should account for the temperature effects of the equipment used."
-                                           "When absent, assume false.")
-    :json-schema/example   "true"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/display-name-key  "Equipment Adjust"
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline "A boolean denoting whether or not programs should account for the temperature effects of the equipment used."
+                                            "When absent, assume false.")
+     :json-schema/example   "true"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::display-grain-temp
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Display Grain Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units."
-    :json-schema/example   "72F"}))
+    {:type                  :string
+     impl/display-name-key  "Display Grain Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units."
+     :json-schema/example   "72F"}))
 
 
 (spec/def ::display-tun-temp
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Display Tun Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units."
-    :json-schema/example   "72F"}))
+    {:type                  :string
+     impl/display-name-key  "Display Tun Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units."
+     :json-schema/example   "72F"}))
 
 
 (spec/def ::display-sparge-temp
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Display Sparge Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units."
-    :json-schema/example   "172F"}))
+    {:type                  :string
+     impl/display-name-key  "Display Sparge Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units."
+     :json-schema/example   "172F"}))
 
 
 (spec/def ::display-tun-weight
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units."
-    :json-schema/example   "72lbs"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units."
+     :json-schema/example   "72lbs"}))
 
 
 (spec/def ::mash
@@ -494,6 +494,7 @@
      :description           "A `::mash-wrapper` record"
      :spec                  (spec/keys :req-un [::mash])}))
 
+
 (spec/def ::mashs
   (st/spec
     {:type          :vector
@@ -501,6 +502,7 @@
      :spec          (spec/coll-of ::mash-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::mash-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::mash-wrapper %2)}))
+
 
 (spec/def ::mashs-wrapper
   (st/spec

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -1,5 +1,5 @@
 (ns common-beer-format.mash
-  "The definition of mash steps and the mash profile records used in BeerXML"
+  "The definition of mash steps and the mash profile records used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
             [clojure.string :as str]
@@ -10,17 +10,17 @@
 
 
 (def mash
-  "A record representing a mash profile"
+  "A record representing a mash profile."
   :mash)
 
 
 (def mash-step
-  "A record representing a mash-step"
+  "A record representing a mash-step."
   :mash-step)
 
 
 (def name
-  "The name of the mash step or mash profile"
+  "The name of the mash step or mash profile."
   :name)
 
 
@@ -46,52 +46,52 @@
 
 
 (def step-temp
-  "The temperature of the mash step should be performed at in degrees Celsius"
+  "The temperature of the mash step should be performed at in degrees Celsius."
   :step-temp)
 
 
 (def step-time
-  "The time in minutes to spend at this step"
+  "The time in minutes to spend at this step."
   :step-time)
 
 
 (def ramp-time
-  "The time in minutes to achieve the desired step temperature"
+  "The time in minutes to achieve the desired step temperature."
   :ramp-time)
 
 
 (def end-temp
-  "The temperature of the mash after the step has completed"
+  "The temperature of the mash after the step has completed."
   :end-temp)
 
 
 (def description
-  "A human-readable description of the mash step"
+  "A human-readable description of the mash step."
   :description)
 
 
 (def water-grain-ratio
-  "A display value for the water:grain ratio after infusion formatted for display in arbitrary units"
+  "A display value for the water:grain ratio after infusion formatted for display in arbitrary units."
   :water-grain-ratio)
 
 
 (def decoction-amt
-  "A display value for the calculated volume of mash to decoct formatted for display in arbitrary units"
+  "A display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
   :decoction-amt)
 
 
 (def infuse-temp
-  "A display value for the temperature of an infusion step formatted for display in arbitrary units"
+  "A display value for the temperature of an infusion step formatted for display in arbitrary units."
   :infuse-temp)
 
 
 (def display-step-temp
-  "A display value for the temperature of the mash step formatted for display in arbitrary units"
+  "A display value for the temperature of the mash step formatted for display in arbitrary units."
   :display-step-temp)
 
 
 (def display-infuse-amt
-  "A display value for the volume of water in the mash step formatted for display in arbitrary units"
+  "A display value for the volume of water in the mash step formatted for display in arbitrary units."
   :display-infuse-amt)
 
 
@@ -111,7 +111,7 @@
 
 
 (def mash-step-types
-  "A set of allowed mash types
+  "A set of allowed mash types.
 
    Currently, the following types are allowed:
 
@@ -131,7 +131,11 @@
                                     #(contains? mash-step-types (str/lower-case %)))
      :gen                 #(spec/gen mash-step-types)
      :description         (impl/multiline "A case-insensitive string representing the type of mash step."
-                                          (impl/set->description mash-step-types))
+                                          (impl/set->description mash-step-types)
+                                          ""
+                                          "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
+                                          "- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature."
+                                          "- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.")
      :json-schema/example "Temperature"}))
 
 
@@ -145,17 +149,18 @@
 
 (spec/def ::step-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius"
-     :json-schema/example "80"}))
+    {:type                 :double
+     impl/display-name-key "Step Temperature"
+     :spec                 ::prim/degrees-celsius
+     :description          "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius."
+     :json-schema/example  "80"}))
 
 
 (spec/def ::step-time
   (st/spec
     {:type                :double
      :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step"
+     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step."
      :json-schema/example "45.0"}))
 
 
@@ -163,63 +168,68 @@
   (st/spec
     {:type                :double
      :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature"
+     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature."
      :json-schema/example "45.0"}))
 
 
 (spec/def ::end-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed"
-     :json-schema/example "80"}))
+    {:type                 :double
+     impl/display-name-key "End Temperature"
+     :spec                 ::prim/degrees-celsius
+     :description          "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius."
+     :json-schema/example  "80"}))
 
 
 (spec/def ::description
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string describing the mash step"
-     :json-schema/example "Stir your grain bag carefully at 140F"}))
+     :description         "A non-empty string describing the mash step."
+     :json-schema/example "Stir your grain bag carefully at 140F."}))
 
 
 (spec/def ::water-grain-ratio
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units."
      :json-schema/example "1.5qt/lb"}))
 
 
 (spec/def ::decoction-amt
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units"
-     :json-schema/example "7.5 liters"}))
+    {:type                 :string
+     impl/display-name-key "Decoction Amount"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
+     :json-schema/example  "7.5 liters"}))
 
 
 (spec/def ::infuse-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units"
-     :json-schema/example "150F"}))
+    {:type                 :string
+     impl/display-name-key "Infusion Temperature"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units."
+     :json-schema/example  "150F"}))
 
 
 (spec/def ::display-step-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units"
-     :json-schema/example "150F"}))
+    {:type                 :string
+     impl/display-name-key "Display Step Temperature"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units."
+     :json-schema/example  "150F"}))
 
 
 (spec/def ::display-infuse-amt
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units"
+    {:type                 :string
+     impl/display-name-key "Display Infusion Amount"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units."
      :json-schema/example "2.2L"}))
 
 
@@ -245,27 +255,28 @@
 
 (spec/def ::mash-step-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::mash record wrapped in a ::mash map"
-     :spec        (spec/keys :req-un [::mash-step])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::mash` record wrapped in a `:mash` map"
+     :spec                 (spec/keys :req-un [::mash-step])}))
 
 
 (spec/def ::mash-steps
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::mash-step records"
+     :description   "A vector of valid `::mash-step` records"
      :spec          (spec/coll-of ::mash-step-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::mash-step-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::mash-step-wrapper %2)}))
 
 
 (def mash-steps
-  "A collection of mash-steps"
+  "A collection of mash-steps."
   :mash-steps)
 
 
 (def grain-temp
-  "The temperature of the grain before adding it to the mash"
+  "The temperature of the grain before adding it to the mash."
   :grain-temp)
 
 
@@ -275,7 +286,7 @@
 
 
 (def tun-temp
-  "The pre-mash temperature of the mash tun"
+  "The pre-mash temperature of the mash tun."
   :tun-temp)
 
 
@@ -305,54 +316,57 @@
 
 
 (def display-grain-temp
-  "A display value for the temperature of the grain before adding it to the mash"
+  "A display value for the temperature of the grain before adding it to the mash."
   :display-grain-temp)
 
 
 (def display-tun-temp
-  "A display value for the temperature of the mash tun"
+  "A display value for the temperature of the mash tun."
   :display-tun-temp)
 
 
 (def display-sparge-temp
-  "A display value for the temperature of the sparge water"
+  "A display value for the temperature of the sparge water."
   :display-sparge-temp)
 
 
 (def display-tun-weight
-  "A display value for the weight of the mash tun"
+  "A display value for the weight of the mash tun."
   :display-tun-weight)
 
 
 (spec/def ::grain-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius"
-     :json-schema/example "80"}))
+    {:type                  :double
+     impl/display-name-key "Grain Temperature"
+     :spec                 ::prim/degrees-celsius
+     :description          "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius."
+     :json-schema/example  "80"}))
 
 
 (spec/def ::tun-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius"
-     :json-schema/example "80"}))
+    {:type                 :double
+     impl/display-name-key "Tun Temperature"
+     :spec                 ::prim/degrees-celsius
+     :description          "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius."
+     :json-schema/example  "80"}))
 
 
 (spec/def ::sparge-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius"
-     :json-schema/example "50"}))
+    {:type                 :double
+     impl/display-name-key "Sparge Temperature"
+     :spec                 ::prim/degrees-celsius
+     :description          "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius."
+     :json-schema/example  "50"}))
 
 
 (spec/def ::ph
   (st/spec
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
-     :description         "A non-negative IEEE-754 floating point number representing the PH of the water"
+     :description         "A non-negative IEEE-754 floating point number representing the PH of the water."
      :json-schema/example "2.5"}))
 
 
@@ -360,7 +374,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/kilogram
-     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms"
+     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
      :json-schema/example "15.0"}))
 
 
@@ -368,7 +382,7 @@
   (st/spec
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius"
+     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
      :json-schema/example "0.2"}))
 
 
@@ -384,33 +398,36 @@
 
 (spec/def ::display-grain-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units"
-     :json-schema/example "72F"}))
+    {:type                 :string
+     impl/display-name-key "Display Grain Temperature"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units."
+     :json-schema/example  "72F"}))
 
 
 (spec/def ::display-tun-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units"
-     :json-schema/example "72F"}))
+    {:type                 :string
+     impl/display-name-key "Display Tun Temperature"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units."
+     :json-schema/example  "72F"}))
 
 
 (spec/def ::display-sparge-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units"
-     :json-schema/example "172F"}))
+    {:type                 :string
+     impl/display-name-key "Display Sparge Temperature"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units."
+     :json-schema/example  "172F"}))
 
 
 (spec/def ::display-tun-weight
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units."
      :json-schema/example "72lbs"}))
 
 
@@ -437,6 +454,7 @@
 
 (spec/def ::mash-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::mash-wrapper record"
-     :spec        (spec/keys :req-un [::mash])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::mash-wrapper` record"
+     :spec                 (spec/keys :req-un [::mash])}))

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -2,7 +2,6 @@
   "The definition of mash steps and the mash profile records used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -97,17 +96,17 @@
 
 (def decoction
   "A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
-  "decoction")
+  "Decoction")
 
 
 (def infusion
   "A mash step where fermentable ingredients steep in water at a specific temperature."
-  "infusion")
+  "Infusion")
 
 
 (def temperature
   "A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source."
-  "temperature")
+  "Temperature")
 
 
 (def mash-step-types
@@ -126,11 +125,9 @@
 (spec/def ::type
   (st/spec
     {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? mash-step-types (str/lower-case %)))
+     :spec                mash-step-types
      :gen                 #(spec/gen mash-step-types)
-     :description         (impl/multiline "A case-insensitive string representing the type of mash step."
+     :description         (impl/multiline "A case-sensitive string representing the type of mash step."
                                           (impl/set->description mash-step-types)
                                           ""
                                           "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
@@ -364,10 +361,11 @@
 
 (spec/def ::ph
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :description         "A non-negative IEEE-754 floating point number representing the PH of the water."
-     :json-schema/example "2.5"}))
+    {:type                 :double
+     impl/display-name-key "PH"
+     :spec                 (spec/and number? #(not (neg? %)))
+     :description          "A non-negative IEEE-754 floating point number representing the PH of the water."
+     :json-schema/example  "2.5"}))
 
 
 (spec/def ::tun-weight

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -124,110 +124,127 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                mash-step-types
-     :gen                 #(spec/gen mash-step-types)
-     :description         (impl/multiline "A case-sensitive string representing the type of mash step."
-                                          (impl/set->description mash-step-types)
-                                          ""
-                                          "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
-                                          "- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature."
-                                          "- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.")
-     :json-schema/example "Temperature"}))
+   {:type                  :string
+    :spec                  mash-step-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen mash-step-types)
+    :description           (impl/multiline "A case-sensitive string representing the type of mash step."
+                                           (impl/set->description mash-step-types)
+                                           ""
+                                           "- Decoction: A mash step where the fermentable ingredients are boiled and then returned to the mash tun."
+                                           "- Infusion: A mash step where fermentable ingredients steep in water at a specific temperature."
+                                           "- Temperature: A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source.")
+    :json-schema/example   "Temperature"}))
 
 
 (spec/def ::infuse-amount
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step."
-     :json-schema/example "5.8"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the volume of water in liters required for an infusion step."
+    :json-schema/example    "5.8"}))
 
 
 (spec/def ::step-temp
   (st/spec
-    {:type                 :double
-     impl/display-name-key "Step Temperature"
-     :spec                 ::prim/degrees-celsius
-     :description          "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius."
-     :json-schema/example  "80"}))
+   {:type                   :double
+    impl/display-name-key   "Step Temperature"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :spec                   ::prim/degrees-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash step should be performed at in degrees Celsius."
+    :json-schema/example    "80"}))
 
 
 (spec/def ::step-time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step."
-     :json-schema/example "45.0"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to spend at this step."
+    :json-schema/example    "45.0"}))
 
 
 (spec/def ::ramp-time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature."
-     :json-schema/example "45.0"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to achieve the desired step temperature."
+    :json-schema/example    "45.0"}))
 
 
 (spec/def ::end-temp
   (st/spec
-    {:type                 :double
-     impl/display-name-key "End Temperature"
-     :spec                 ::prim/degrees-celsius
-     :description          "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius."
-     :json-schema/example  "80"}))
+   {:type                   :double
+    impl/display-name-key   "End Temperature"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :spec                   ::prim/degrees-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the temperature of the mash after the step has completed in degrees Celsius."
+    :json-schema/example    "80"}))
 
 
 (spec/def ::description
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string describing the mash step."
-     :json-schema/example "Stir your grain bag carefully at 140F."}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string describing the mash step."
+    :json-schema/example   "Stir your grain bag carefully at 140F."}))
 
 
 (spec/def ::water-grain-ratio
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units."
-     :json-schema/example "1.5qt/lb"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the water:grain ratio after infusion formatted for display in arbitrary units."
+    :json-schema/example   "1.5qt/lb"}))
 
 
 (spec/def ::decoction-amt
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Decoction Amount"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
-     :json-schema/example  "7.5 liters"}))
+   {:type                  :string
+    impl/display-name-key  "Decoction Amount"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for the calculated volume of mash to decoct formatted for display in arbitrary units."
+    :json-schema/example   "7.5 liters"}))
 
 
 (spec/def ::infuse-temp
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Infusion Temperature"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units."
-     :json-schema/example  "150F"}))
+   {:type                  :string
+    impl/display-name-key  "Infusion Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for the temperature of an infusion step formatted for display in arbitrary units."
+    :json-schema/example   "150F"}))
 
 
 (spec/def ::display-step-temp
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Display Step Temperature"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units."
-     :json-schema/example  "150F"}))
+   {:type                  :string
+    impl/display-name-key  "Display Step Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for the temperature of an arbitrary step formatted for display in arbitrary units."
+    :json-schema/example   "150F"}))
 
 
 (spec/def ::display-infuse-amt
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Display Infusion Amount"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units."
-     :json-schema/example "2.2L"}))
+   {:type                  :string
+    impl/display-name-key  "Display Infusion Amount"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for the volume of infused liquid formatted for display in arbitrary units."
+    :json-schema/example   "2.2L"}))
 
 
 (spec/def ::mash-step
@@ -252,19 +269,21 @@
 
 (spec/def ::mash-step-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::mash` record wrapped in a `:mash` map"
-     :spec                 (spec/keys :req-un [::mash-step])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::mash` record wrapped in a `:mash` map"
+     :spec                  (spec/keys :req-un [::mash-step])}))
 
 
 (spec/def ::mash-steps
   (st/spec
-    {:type          :vector
-     :description   "A vector of valid `::mash-step` records"
-     :spec          (spec/coll-of ::mash-step-wrapper :into [] :kind vector?)
-     :decode/string #(impl/decode-sequence %1 ::mash-step-wrapper %2)
-     :encode/string #(impl/encode-sequence %1 ::mash-step-wrapper %2)}))
+    {:type                  :vector
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::mash-step` record set."
+     :spec                  (spec/coll-of ::mash-step-wrapper :into [] :kind vector?)
+     :decode/string         #(impl/decode-sequence %1 ::mash-step-wrapper %2)
+     :encode/string         #(impl/encode-sequence %1 ::mash-step-wrapper %2)}))
 
 
 (def mash-steps
@@ -334,99 +353,116 @@
 
 (spec/def ::grain-temp
   (st/spec
-    {:type                  :double
-     impl/display-name-key "Grain Temperature"
-     :spec                 ::prim/degrees-celsius
-     :description          "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius."
-     :json-schema/example  "80"}))
+   {:type                   :double
+    impl/display-name-key   "Grain Temperature"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :spec                   ::prim/degrees-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain before adding it to the mash in degrees Celsius."
+    :json-schema/example    "80"}))
 
 
 (spec/def ::tun-temp
   (st/spec
-    {:type                 :double
-     impl/display-name-key "Tun Temperature"
-     :spec                 ::prim/degrees-celsius
-     :description          "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius."
-     :json-schema/example  "80"}))
+   {:type                   :double
+    impl/display-name-key   "Tun Temperature"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :spec                   ::prim/degrees-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the temperature of the grain tun in degrees Celsius."
+    :json-schema/example    "80"}))
 
 
 (spec/def ::sparge-temp
   (st/spec
-    {:type                 :double
-     impl/display-name-key "Sparge Temperature"
-     :spec                 ::prim/degrees-celsius
-     :description          "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius."
-     :json-schema/example  "50"}))
+   {:type                   :double
+    impl/display-name-key   "Sparge Temperature"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :spec                   ::prim/degrees-celsius
+    :description            "A non-negative IEEE-754 floating point number representing the temperature of the sparge in degrees Celsius."
+    :json-schema/example    "50"}))
 
 
 (spec/def ::ph
   (st/spec
-    {:type                 :double
-     impl/display-name-key "PH"
-     :spec                 (spec/and number? #(not (neg? %)))
-     :description          "A non-negative IEEE-754 floating point number representing the PH of the water."
-     :json-schema/example  "2.5"}))
+   {:type                  :double
+    impl/display-name-key  "PH"
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :spec                  ::prim/non-negative-number
+    :description           "A non-negative IEEE-754 floating point number representing the PH of the water."
+    :json-schema/example   "2.5"}))
 
 
 (spec/def ::tun-weight
   (st/spec
-    {:type                :double
-     :spec                ::prim/kilogram
-     :description         "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
-     :json-schema/example "15.0"}))
+   {:type                   :double
+    :spec                   ::prim/kilogram
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-kilogram
+    :description            "A non-negative IEEE-754 floating point number representing the weight of the of the mash tun in kilograms."
+    :json-schema/example    "15.0"}))
 
 
 (spec/def ::tun-specific-heat
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
-     :json-schema/example "0.2"}))
+   {:type                   :double
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-calories-per-gram-degree-celsius
+    :spec                   ::prim/non-negative-number
+    :description            "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius."
+    :json-schema/example    "0.2"}))
 
 
 (spec/def ::equip-adjust
   (st/spec
-    {:spec                ::prim/boolean
-     :description         (impl/multiline "A boolean denoting whether or not programs should account for the temperature effects of the equipment used."
-                                          "When absent, assume false.")
-     :json-schema/example "true"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                  ::prim/boolean
+    impl/display-name-key  "Equipment Adjust"
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline "A boolean denoting whether or not programs should account for the temperature effects of the equipment used."
+                                           "When absent, assume false.")
+    :json-schema/example   "true"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::display-grain-temp
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Display Grain Temperature"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units."
-     :json-schema/example  "72F"}))
+   {:type                  :string
+    impl/display-name-key  "Display Grain Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for grain temperature formatted for display in arbitrary units."
+    :json-schema/example   "72F"}))
 
 
 (spec/def ::display-tun-temp
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Display Tun Temperature"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units."
-     :json-schema/example  "72F"}))
+   {:type                  :string
+    impl/display-name-key  "Display Tun Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for mash tun temperature formatted for display in arbitrary units."
+    :json-schema/example   "72F"}))
 
 
 (spec/def ::display-sparge-temp
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Display Sparge Temperature"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units."
-     :json-schema/example  "172F"}))
+   {:type                  :string
+    impl/display-name-key  "Display Sparge Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting a display value for sparging process temperature formatted for display in arbitrary units."
+    :json-schema/example   "172F"}))
 
 
 (spec/def ::display-tun-weight
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units."
-     :json-schema/example "72lbs"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for mash tun weight formatted for display in arbitrary units."
+    :json-schema/example   "72lbs"}))
 
 
 (spec/def ::mash
@@ -452,7 +488,24 @@
 
 (spec/def ::mash-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::mash-wrapper` record"
-     :spec                 (spec/keys :req-un [::mash])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::mash-wrapper` record"
+     :spec                  (spec/keys :req-un [::mash])}))
+
+(spec/def ::mashs
+  (st/spec
+    {:type          :vector
+     :description   "A vector of valid `::mash` records."
+     :spec          (spec/coll-of ::mash-wrapper :into [] :kind vector?)
+     :decode/string #(impl/decode-sequence %1 ::mash-wrapper %2)
+     :encode/string #(impl/encode-sequence %1 ::mash-wrapper %2)}))
+
+(spec/def ::mashs-wrapper
+  (st/spec
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::mashs` record record set."
+     :spec                  (spec/keys :req-un [::mashs])}))

--- a/src/common_beer_format/mash.cljc
+++ b/src/common_beer_format/mash.cljc
@@ -31,9 +31,9 @@
 
 (def type
   "The type of mash step.
-   
+
    Currently, the following types are allowed:
-   
+
    - `decoction` - A mash step where the fermentable ingredients are boiled and then returned to the mash tun.
    - `infusion` - A mash step where fermentable ingredients steep in water at a specific temperature.
    - `temperature` - A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source."
@@ -112,9 +112,9 @@
 
 (def mash-step-types
   "A set of allowed mash types
-   
+
    Currently, the following types are allowed:
-   
+
    - `decoction` - A mash step where the fermentable ingredients are boiled and then returned to the mash tun.
    - `infusion` - A mash step where fermentable ingredients steep in water at a specific temperature.
    - `temperature` - A mash step where the temperature of the mash is held at a specific temperature for a specific time by an external source."
@@ -368,7 +368,7 @@
   (st/spec
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
-     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mashtun in Calories per gram-degree Celsius"
+     :description         "A non-negative IEEE-754 floating point number representing the specific heat of the mash tun in Calories per gram-degree Celsius"
      :json-schema/example "0.2"}))
 
 

--- a/src/common_beer_format/miscs.cljc
+++ b/src/common_beer_format/miscs.cljc
@@ -2,7 +2,6 @@
   "The definition of a misc record used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -31,9 +30,9 @@
 
 (def type
   "The type of the miscellaneous ingredient.
-   
+
    Currently, BeerXML Supports the following types:
-   
+
    - `spice`: A spice, such as cinnamon or ginger.
    - `fining`: A fining agent, such as isinglass.
    - `water agent`: A water agent, such as campden tablet.
@@ -45,9 +44,9 @@
 
 (def use
   "How the miscellaneous ingredient is used in the brewing process.
-   
+
    Currently, BeerXML supports the following uses:
-   
+
    - `boil`: The ingredient is added to the boil.
    - `mash`: The ingredient is added to the mash.
    - `primary`: The ingredient is added to the primary fermentation.
@@ -58,7 +57,7 @@
 
 (def time
   "The time in minutes the ingredient is added to the beer.
-   
+
    For `boil` this is the boil time.
    For `mash` this is the mash time.
    For `primary`, `secondary`, and `bottling` this is the amount of time the ingredient spent in that state."
@@ -102,39 +101,39 @@
 
 (def fining
   "A fining agent, such as isinglass."
-  "fining")
+  "Fining")
 
 
 (def flavor
   "A flavoring, such as orange peel or a flavor concentrate."
-  "flavor")
+  "Flavor")
 
 
 (def herb
   "An herb, such as mint."
-  "herb")
+  "Herb")
 
 
 (def other
   "Any other type of miscellaneous ingredient."
-  "other")
+  "Other")
 
 
 (def spice
   "A spice, such as cinnamon or ginger."
-  "spice")
+  "Spice")
 
 
 (def water-agent
   "A water agent, such as campden tablet."
-  "water agent")
+  "Water Agent")
 
 
 (def misc-types
   "A set of the miscellaneous ingredient types supported by BeerXML.
-   
+
    Currently, BeerXML Supports the following types:
-   
+
    - `spice`: A spice, such as cinnamon or ginger.
    - `fining`: A fining agent, such as isinglass.
    - `water agent`: A water agent, such as campden tablet.
@@ -151,51 +150,57 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? misc-types (str/lower-case %)))
-     :gen                 #(spec/gen misc-types)
-     :description         (impl/multiline "A case-insensitive string representing the type of the miscellaneous item added to the beer."
-                                          (impl/set->description misc-types))
-     :json-schema/example "Spice"}))
+   {:type                :string
+    :spec                misc-types
+    :gen                 #(spec/gen misc-types)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the type of the miscellaneous item added to the beer."
+                          (impl/set->description misc-types)
+                          ""
+                          "- Fining: A fining agent, such as isinglass."
+                          "- Flavor: A flavoring, such as orange peel or a flavor concentrate."
+                          "- Herb: An herb, such as mint."
+                          "- Other: Any other type of miscellaneous ingredient."
+                          "- Spice: A spice, such as cinnamon or ginger."
+                          "- Water Agent: A water agent, such as campden tablet.")
+    :json-schema/example "Spice"}))
 
 
 (def boil
   "The ingredient is added to the boil."
-  "boil")
+  "Boil")
 
 
 (def mash
   "The ingredient is added to the mash."
-  "mash")
+  "Mash")
 
 
 (def primary
   "The ingredient is added to the primary fermentation."
-  "primary")
+  "Primary")
 
 
 (def secondary
   "The ingredient is added to the secondary fermentation."
-  "secondary")
+  "Secondary")
 
 
 (def bottling
   "The ingredient is added to the bottling process."
-  "bottling")
+  "Bottling")
 
 
 (def misc-uses
   "A set of the miscellaneous ingredient uses supported by BeerXML.
-   
+
    Currently, BeerXML supports the following uses:
-   
+
    - `boil`: The ingredient is added to the boil.
    - `mash`: The ingredient is added to the mash.
    - `primary`: The ingredient is added to the primary fermentation.
    - `secondary`: The ingredient is added to the secondary fermentation.
-   - `bottling`: The ingredient is added to the bottling process."
+   - `bottling`: The ingredient is added during the bottling process."
   #{boil
     mash
     primary
@@ -205,26 +210,31 @@
 
 (spec/def ::use
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? misc-uses (str/lower-case %)))
-     :gen                 #(spec/gen misc-uses)
-     :description         (impl/multiline
-                            "A case-insensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
-                            (impl/set->description misc-uses))
-     :json-schema/example "Mash"}))
+   {:type                :string
+    :spec                misc-uses
+    :gen                 #(spec/gen misc-uses)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
+                          (impl/set->description misc-uses)
+                          ""
+                          "- Boil: The ingredient is added to the boil."
+                          "- Mash: The ingredient is added to the mash."
+                          "- Primary: The ingredient is added to the primary fermentation."
+                          "- Secondary: The ingredient is added to the secondary fermentation."
+                          "- Bottling: The ingredient is added during the bottling process.")
+    :json-schema/example "Mash"}))
 
 
 (spec/def ::time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         (impl/multiline "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the :use field."
-                                          "For \"Boil\" this is the boil time."
-                                          "For \"Mash\" this is the mash time."
-                                          "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
-     :json-schema/example "15.0"}))
+   {:type                :double
+    :spec                ::prim/minute
+    :description         (impl/multiline
+                          "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the :use field."
+                          "For \"Boil\" this is the boil time."
+                          "For \"Mash\" this is the mash time."
+                          "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
+    :json-schema/example "15.0"}))
 
 
 (spec/def ::use-for
@@ -237,40 +247,46 @@
 
 (spec/def ::misc
   (st/spec
-    {:type        :map
-     :description "A record representing a miscellaneous ingredient in a beer recipe."
-     :spec        (spec/keys :req-un [::prim/name
-                                      ::prim/version
-                                      ::type
-                                      ::use
-                                      ::time
-                                      ::prim/amount]
-                             :opt-un [::prim/amount-is-weight
-                                      ::use-for
-                                      ::prim/notes
-                                      ::prim/display-amount
-                                      ::prim/inventory
-                                      ::prim/display-time])}))
+    {:type                 :map
+     impl/display-name-key "Miscellaneous Ingredient"
+     :description          "A record representing a miscellaneous ingredient in a beer recipe."
+     :spec                 (spec/keys :req-un [::prim/name
+                                               ::prim/version
+                                               ::type
+                                               ::use
+                                               ::time
+                                               ::prim/amount]
+                                      :opt-un [::prim/amount-is-weight
+                                               ::use-for
+                                               ::prim/notes
+                                               ::prim/display-amount
+                                               ::prim/inventory
+                                               ::prim/display-time])}))
 
 
 (spec/def ::misc-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::misc record wrapped in a :misc map."
-     :spec        (spec/keys :req-un [::misc])}))
+    {:type                 :map
+     impl/display-name-key "Miscellaneous Ingredient Wrapper"
+     impl/wrapper-spec-key true
+     :description          "A `::misc` record wrapped in a `:misc` map."
+     :spec                 (spec/keys :req-un [::misc])}))
 
 
 (spec/def ::miscs
   (st/spec
-    {:type          :vector
-     :description   "A vector of valid ::misc records."
-     :spec          (spec/coll-of ::misc-wrapper :into [] :kind vector?)
-     :decode/string #(impl/decode-sequence %1 ::misc-wrapper %2)
-     :encode/string #(impl/encode-sequence %1 ::misc-wrapper %2)}))
+    {:type                 :vector
+     impl/display-name-key "Miscellaneous Ingredients"
+     :description          "A vector of valid `::misc` records."
+     :spec                 (spec/coll-of ::misc-wrapper :into [] :kind vector?)
+     :decode/string        #(impl/decode-sequence %1 ::misc-wrapper %2)
+     :encode/string        #(impl/encode-sequence %1 ::misc-wrapper %2)}))
 
 
 (spec/def ::miscs-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::miscs record."
-     :spec        (spec/keys :req-un [::miscs])}))
+    {:type                 :map
+     impl/display-name-key "Miscellaneous Ingredients Wrapper"
+     impl/wrapper-spec-key true
+     :description          "A `::miscs` record."
+     :spec                 (spec/keys :req-un [::miscs])}))

--- a/src/common_beer_format/miscs.cljc
+++ b/src/common_beer_format/miscs.cljc
@@ -150,20 +150,21 @@
 
 (spec/def ::type
   (st/spec
-   {:type                :string
-    :spec                misc-types
-    :gen                 #(spec/gen misc-types)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the type of the miscellaneous item added to the beer."
-                          (impl/set->description misc-types)
-                          ""
-                          "- Fining: A fining agent, such as isinglass."
-                          "- Flavor: A flavoring, such as orange peel or a flavor concentrate."
-                          "- Herb: An herb, such as mint."
-                          "- Other: Any other type of miscellaneous ingredient."
-                          "- Spice: A spice, such as cinnamon or ginger."
-                          "- Water Agent: A water agent, such as campden tablet.")
-    :json-schema/example "Spice"}))
+   {:type                  :string
+    :spec                  misc-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen misc-types)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the type of the miscellaneous item added to the beer."
+                            (impl/set->description misc-types)
+                            ""
+                            "- Fining: A fining agent, such as isinglass."
+                            "- Flavor: A flavoring, such as orange peel or a flavor concentrate."
+                            "- Herb: An herb, such as mint."
+                            "- Other: Any other type of miscellaneous ingredient."
+                            "- Spice: A spice, such as cinnamon or ginger."
+                            "- Water Agent: A water agent, such as campden tablet.")
+    :json-schema/example   "Spice"}))
 
 
 (def boil
@@ -210,39 +211,43 @@
 
 (spec/def ::use
   (st/spec
-   {:type                :string
-    :spec                misc-uses
-    :gen                 #(spec/gen misc-uses)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
-                          (impl/set->description misc-uses)
-                          ""
-                          "- Boil: The ingredient is added to the boil."
-                          "- Mash: The ingredient is added to the mash."
-                          "- Primary: The ingredient is added to the primary fermentation."
-                          "- Secondary: The ingredient is added to the secondary fermentation."
-                          "- Bottling: The ingredient is added during the bottling process.")
-    :json-schema/example "Mash"}))
+   {:type                  :string
+    :spec                  misc-uses
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen misc-uses)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
+                            (impl/set->description misc-uses)
+                            ""
+                            "- Boil: The ingredient is added to the boil."
+                            "- Mash: The ingredient is added to the mash."
+                            "- Primary: The ingredient is added to the primary fermentation."
+                            "- Secondary: The ingredient is added to the secondary fermentation."
+                            "- Bottling: The ingredient is added during the bottling process.")
+    :json-schema/example   "Mash"}))
 
 
 (spec/def ::time
   (st/spec
-   {:type                :double
-    :spec                ::prim/minute
-    :description         (impl/multiline
-                          "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the :use field."
-                          "For \"Boil\" this is the boil time."
-                          "For \"Mash\" this is the mash time."
-                          "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
-    :json-schema/example "15.0"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            (impl/multiline
+                             "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the `:use` field."
+                             "For \"Boil\" this is the boil time."
+                             "For \"Mash\" this is the mash time."
+                             "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
+    :json-schema/example    "15.0"}))
 
 
 (spec/def ::use-for
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting what the ingredient is used for."
-     :json-schema/example "Used to impart a mild, zesty flavor"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting what the ingredient is used for."
+    :json-schema/example   "Used to impart a mild, zesty flavor"}))
 
 
 (spec/def ::misc
@@ -266,11 +271,12 @@
 
 (spec/def ::misc-wrapper
   (st/spec
-    {:type                 :map
-     impl/display-name-key "Miscellaneous Ingredient Wrapper"
-     impl/wrapper-spec-key true
-     :description          "A `::misc` record wrapped in a `:misc` map."
-     :spec                 (spec/keys :req-un [::misc])}))
+    {:type                  :map
+     impl/display-name-key  "Miscellaneous Ingredient Wrapper"
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::misc` record wrapped in a `:misc` map."
+     :spec                  (spec/keys :req-un [::misc])}))
 
 
 (spec/def ::miscs
@@ -285,8 +291,9 @@
 
 (spec/def ::miscs-wrapper
   (st/spec
-    {:type                 :map
-     impl/display-name-key "Miscellaneous Ingredients Wrapper"
-     impl/wrapper-spec-key true
-     :description          "A `::miscs` record."
-     :spec                 (spec/keys :req-un [::miscs])}))
+    {:type                  :map
+     impl/display-name-key  "Miscellaneous Ingredients Wrapper"
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::miscs` record."
+     :spec                  (spec/keys :req-un [::miscs])}))

--- a/src/common_beer_format/miscs.cljc
+++ b/src/common_beer_format/miscs.cljc
@@ -150,21 +150,21 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  misc-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen misc-types)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the type of the miscellaneous item added to the beer."
-                            (impl/set->description misc-types)
-                            ""
-                            "- Fining: A fining agent, such as isinglass."
-                            "- Flavor: A flavoring, such as orange peel or a flavor concentrate."
-                            "- Herb: An herb, such as mint."
-                            "- Other: Any other type of miscellaneous ingredient."
-                            "- Spice: A spice, such as cinnamon or ginger."
-                            "- Water Agent: A water agent, such as campden tablet.")
-    :json-schema/example   "Spice"}))
+    {:type                  :string
+     :spec                  misc-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen misc-types)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the type of the miscellaneous item added to the beer."
+                              (impl/set->description misc-types)
+                              ""
+                              "- Fining: A fining agent, such as isinglass."
+                              "- Flavor: A flavoring, such as orange peel or a flavor concentrate."
+                              "- Herb: An herb, such as mint."
+                              "- Other: Any other type of miscellaneous ingredient."
+                              "- Spice: A spice, such as cinnamon or ginger."
+                              "- Water Agent: A water agent, such as campden tablet.")
+     :json-schema/example   "Spice"}))
 
 
 (def boil
@@ -211,43 +211,43 @@
 
 (spec/def ::use
   (st/spec
-   {:type                  :string
-    :spec                  misc-uses
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen misc-uses)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
-                            (impl/set->description misc-uses)
-                            ""
-                            "- Boil: The ingredient is added to the boil."
-                            "- Mash: The ingredient is added to the mash."
-                            "- Primary: The ingredient is added to the primary fermentation."
-                            "- Secondary: The ingredient is added to the secondary fermentation."
-                            "- Bottling: The ingredient is added during the bottling process.")
-    :json-schema/example   "Mash"}))
+    {:type                  :string
+     :spec                  misc-uses
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen misc-uses)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the point in the brewing cycle the miscellaneous ingredient is added to the beer."
+                              (impl/set->description misc-uses)
+                              ""
+                              "- Boil: The ingredient is added to the boil."
+                              "- Mash: The ingredient is added to the mash."
+                              "- Primary: The ingredient is added to the primary fermentation."
+                              "- Secondary: The ingredient is added to the secondary fermentation."
+                              "- Bottling: The ingredient is added during the bottling process.")
+     :json-schema/example   "Mash"}))
 
 
 (spec/def ::time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            (impl/multiline
-                             "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the `:use` field."
-                             "For \"Boil\" this is the boil time."
-                             "For \"Mash\" this is the mash time."
-                             "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
-    :json-schema/example    "15.0"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            (impl/multiline
+                               "A non-negative IEEE-754 floating point number representing the time in minutes the ingredient was added dependant on the `:use` field."
+                               "For \"Boil\" this is the boil time."
+                               "For \"Mash\" this is the mash time."
+                               "For \"Primary\", \"Secondary\", and \"Bottling\" this is the amount of time the ingredient spent in that state.")
+     :json-schema/example    "15.0"}))
 
 
 (spec/def ::use-for
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting what the ingredient is used for."
-    :json-schema/example   "Used to impart a mild, zesty flavor"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting what the ingredient is used for."
+     :json-schema/example   "Used to impart a mild, zesty flavor"}))
 
 
 (spec/def ::misc

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -13,7 +13,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing weight in kilograms"
+     :description         "A non-negative IEEE-754 floating point number representing weight in kilograms."
      :json-schema/example "10.7"}))
 
 
@@ -22,7 +22,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing volume in liters"
+     :description         "A non-negative IEEE-754 floating point number representing volume in liters."
      :json-schema/example "12.3"}))
 
 
@@ -31,7 +31,7 @@
     {:type                :double
      :spec                number?
      :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing degress in Celsius"
+     :description         "An IEEE-754 floating point number representing degress in Celsius."
      :json-schema/example "-10.7"}))
 
 
@@ -40,7 +40,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing time in minutes"
+     :description         "A non-negative IEEE-754 floating point number representing time in minutes."
      :json-schema/example "45.0"}))
 
 
@@ -49,7 +49,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water"
+     :description         "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water."
      :json-schema/example "1.045"}))
 
 
@@ -58,7 +58,7 @@
     {:type                :double
      :spec                (spec/and number? #(not (neg? %)))
      :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing pressure in kilopascals"
+     :description         "A non-negative IEEE-754 floating point number representing pressure in kilopascals."
      :json-schema/example "101.325"}))
 
 
@@ -67,14 +67,14 @@
     {:type                :double
      :spec                number?
      :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing a human-readable percentage - e.g 5.5"
+     :description         "An IEEE-754 floating point number representing a human-readable percentage out of 100 - e.g 5.5 to represent 5.5%"
      :json-schema/example "4.5"}))
 
 
 (spec/def ::boolean
   (st/spec
     {:spec                np/boolean?
-     :description         "A boolean logic value of true or false"
+     :description         "A boolean logic value of true or false."
      :json-schema/example "false"
      :gen                 #(spec/gen boolean?)
      :decode/string       impl/decode-boolean
@@ -86,7 +86,7 @@
     {:type                :string
      :spec                (spec/and string? #(not (str/blank? %)))
      :description         "A non-empty string"
-     :json-schema/example "Used to impart a mild, zesty flavor"}))
+     :json-schema/example "Used to impart a mild, zesty flavor."}))
 
 
 (spec/def ::version
@@ -94,7 +94,7 @@
     {:type                :long
      :spec                #(= 1 %)
      :gen                 #(spec/gen #{1})
-     :description         "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists"
+     :description         "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists."
      :json-schema/example "1"}))
 
 
@@ -102,7 +102,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string representing the name of the ingredient"
+     :description         "A non-empty string representing the name of the ingredient."
      :json-schema/example "Citra"}))
 
 
@@ -110,7 +110,7 @@
   (st/spec
     {:type                :double
      :spec                ::kilogram
-     :description         "A ::kilogram value representing the amount of a particular ingredient"
+     :description         "A ::kilogram value representing the amount of a particular ingredient."
      :json-schema/example "12.5"}))
 
 
@@ -118,7 +118,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string representing any notes about the subject"
+     :description         "A non-empty string representing any notes about the subject."
      :json-schema/example "A wonderful, zesty aroma"}))
 
 
@@ -126,7 +126,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting the place of origin for a particular ingredient"
+     :description         "A non-empty string denoting the place of origin for a particular ingredient."
      :json-schema/example "Nice, France"}))
 
 
@@ -134,7 +134,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting ingredients with me bay used in place of those denoted in the record"
+     :description         "A non-empty string denoting ingredients with me bay used in place of those denoted in the record."
      :json-schema/example "Citra or Sorachi"}))
 
 
@@ -154,7 +154,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units."
      :json-schema/example "100 g"}))
 
 
@@ -162,7 +162,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units."
      :json-schema/example "100 lbs"}))
 
 
@@ -170,5 +170,5 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units."
      :json-schema/example "10 days"}))

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -126,7 +126,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting the place of originfor a particular ingredient"
+     :description         "A non-empty string denoting the place of origin for a particular ingredient"
      :json-schema/example "Nice, France"}))
 
 
@@ -134,7 +134,7 @@
   (st/spec
     {:type                :string
      :spec                ::text
-     :description         "A non-empty string denoting ingredients with me bay used in place of those deonted in the reocrd"
+     :description         "A non-empty string denoting ingredients with me bay used in place of those denoted in the record"
      :json-schema/example "Citra or Sorachi"}))
 
 

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -7,120 +7,121 @@
             [nnichols.predicate :as np]
             [spec-tools.core :as st]))
 
+
 (spec/def ::non-negative-number
   (st/spec
-   {:type                  :double
-    :spec                  (spec/and number? #(not (neg? %)))
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-positive-double-generator
-    :description           "A non-negative IEEE-754 floating point number."
-    :json-schema/example   "10.7"}))
+    {:type                  :double
+     :spec                  (spec/and number? #(not (neg? %)))
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A non-negative IEEE-754 floating point number."
+     :json-schema/example   "10.7"}))
 
 
 (spec/def ::kilogram
   (st/spec
-   {:type                   :double
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-kilogram
-    :spec                   ::non-negative-number
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing weight in kilograms."
-    :json-schema/example    "10.7"}))
+    {:type                   :double
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-kilogram
+     :spec                   ::non-negative-number
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing weight in kilograms."
+     :json-schema/example    "10.7"}))
 
 
 (spec/def ::liter
   (st/spec
-   {:type                   :double
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :spec                   ::non-negative-number
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing volume in liters."
-    :json-schema/example    "12.3"}))
+    {:type                   :double
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :spec                   ::non-negative-number
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing volume in liters."
+     :json-schema/example    "12.3"}))
 
 
 (spec/def ::degrees-celsius
   (st/spec
-   {:type                   :double
-    :spec                   number?
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :gen                    impl/real-double-generator
-    :description            "An IEEE-754 floating point number representing degress in Celsius."
-    :json-schema/example    "-10.7"}))
+    {:type                   :double
+     :spec                   number?
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :gen                    impl/real-double-generator
+     :description            "An IEEE-754 floating point number representing degress in Celsius."
+     :json-schema/example    "-10.7"}))
 
 
 (spec/def ::minute
   (st/spec
-   {:type                   :double
-    :spec                   ::non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing time in minutes."
-    :json-schema/example    "45.0"}))
+    {:type                   :double
+     :spec                   ::non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing time in minutes."
+     :json-schema/example    "45.0"}))
 
 
 (spec/def ::specific-gravity
   (st/spec
-   {:type                   :double
-    :spec                   (spec/and number? pos?)
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-specific-gravity
-    :gen                    impl/real-positive-double-generator
-    :description            "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water."
-    :json-schema/example    "1.045"}))
+    {:type                   :double
+     :spec                   (spec/and number? pos?)
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :gen                    impl/real-positive-double-generator
+     :description            "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water."
+     :json-schema/example    "1.045"}))
 
 
 (spec/def ::kilopascal
   (st/spec
-   {:type                   :double
-    :spec                   ::non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-kilopascal
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing pressure in kilopascals."
-    :json-schema/example    "101.325"}))
+    {:type                   :double
+     :spec                   ::non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-kilopascal
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing pressure in kilopascals."
+     :json-schema/example    "101.325"}))
 
 
 (spec/def ::percent
   (st/spec
-   {:type                   :double
-    :spec                   number?
-    impl/beer-xml-type-key  impl/beer-xml-percentage
-    :gen                    impl/real-double-generator
-    :description            "An IEEE-754 floating point number representing a human-readable percentage out of 100 - e.g 5.5 to represent 5.5%"
-    :json-schema/example    "4.5"}))
+    {:type                   :double
+     :spec                   number?
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     :gen                    impl/real-double-generator
+     :description            "An IEEE-754 floating point number representing a human-readable percentage out of 100 - e.g 5.5 to represent 5.5%"
+     :json-schema/example    "4.5"}))
 
 
 (spec/def ::boolean
   (st/spec
-   {:spec                  np/boolean?
-    :description           "A boolean logic value of true or false."
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :json-schema/example   "false"
-    :gen                   #(spec/gen boolean?)
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  np/boolean?
+     :description           "A boolean logic value of true or false."
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :json-schema/example   "false"
+     :gen                   #(spec/gen boolean?)
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::text
   (st/spec
-   {:type                  :string
-    :spec                  (spec/and string? #(not (str/blank? %)))
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string"
-    :json-schema/example   "Used to impart a mild, zesty flavor."}))
+    {:type                  :string
+     :spec                  (spec/and string? #(not (str/blank? %)))
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string"
+     :json-schema/example   "Used to impart a mild, zesty flavor."}))
 
 
 (spec/def ::version
   (st/spec
-   {:type                  :long
-    :spec                  #(= 1 %)
-    impl/beer-xml-type-key impl/beer-xml-integer
-    :gen                   #(spec/gen #{1})
-    :description           "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists."
-    :json-schema/example   "1"}))
+    {:type                  :long
+     :spec                  #(= 1 %)
+     impl/beer-xml-type-key impl/beer-xml-integer
+     :gen                   #(spec/gen #{1})
+     :description           "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists."
+     :json-schema/example   "1"}))
 
 
 (spec/def ::name
@@ -139,9 +140,9 @@
      impl/beer-xml-type-key  impl/beer-xml-floating-point
      impl/beer-xml-units-key [impl/beer-xml-kilogram impl/beer-xml-liter]
      :description            (impl/multiline
-                              "A value representing the amount of a particular ingredient."
-                              "When measuring weight, this is in kilograms."
-                              "When measuring volume, this is in liters.")
+                               "A value representing the amount of a particular ingredient."
+                               "When measuring weight, this is in kilograms."
+                               "When measuring volume, this is in liters.")
      :json-schema/example    "12.5"}))
 
 

--- a/src/common_beer_format/primitives.cljc
+++ b/src/common_beer_format/primitives.cljc
@@ -7,168 +7,206 @@
             [nnichols.predicate :as np]
             [spec-tools.core :as st]))
 
+(spec/def ::non-negative-number
+  (st/spec
+   {:type                  :double
+    :spec                  (spec/and number? #(not (neg? %)))
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-positive-double-generator
+    :description           "A non-negative IEEE-754 floating point number."
+    :json-schema/example   "10.7"}))
+
 
 (spec/def ::kilogram
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing weight in kilograms."
-     :json-schema/example "10.7"}))
+   {:type                   :double
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-kilogram
+    :spec                   ::non-negative-number
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing weight in kilograms."
+    :json-schema/example    "10.7"}))
 
 
 (spec/def ::liter
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing volume in liters."
-     :json-schema/example "12.3"}))
+   {:type                   :double
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :spec                   ::non-negative-number
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing volume in liters."
+    :json-schema/example    "12.3"}))
 
 
 (spec/def ::degrees-celsius
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing degress in Celsius."
-     :json-schema/example "-10.7"}))
+   {:type                   :double
+    :spec                   number?
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :gen                    impl/real-double-generator
+    :description            "An IEEE-754 floating point number representing degress in Celsius."
+    :json-schema/example    "-10.7"}))
 
 
 (spec/def ::minute
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing time in minutes."
-     :json-schema/example "45.0"}))
+   {:type                   :double
+    :spec                   ::non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing time in minutes."
+    :json-schema/example    "45.0"}))
 
 
 (spec/def ::specific-gravity
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water."
-     :json-schema/example "1.045"}))
+   {:type                   :double
+    :spec                   (spec/and number? pos?)
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-specific-gravity
+    :gen                    impl/real-positive-double-generator
+    :description            "A positive IEEE-754 floating point number representing the specific gravity relative to the weight of the same size sample of water."
+    :json-schema/example    "1.045"}))
 
 
 (spec/def ::kilopascal
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing pressure in kilopascals."
-     :json-schema/example "101.325"}))
+   {:type                   :double
+    :spec                   ::non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-kilopascal
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing pressure in kilopascals."
+    :json-schema/example    "101.325"}))
 
 
 (spec/def ::percent
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing a human-readable percentage out of 100 - e.g 5.5 to represent 5.5%"
-     :json-schema/example "4.5"}))
+   {:type                   :double
+    :spec                   number?
+    impl/beer-xml-type-key  impl/beer-xml-percentage
+    :gen                    impl/real-double-generator
+    :description            "An IEEE-754 floating point number representing a human-readable percentage out of 100 - e.g 5.5 to represent 5.5%"
+    :json-schema/example    "4.5"}))
 
 
 (spec/def ::boolean
   (st/spec
-    {:spec                np/boolean?
-     :description         "A boolean logic value of true or false."
-     :json-schema/example "false"
-     :gen                 #(spec/gen boolean?)
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                  np/boolean?
+    :description           "A boolean logic value of true or false."
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :json-schema/example   "false"
+    :gen                   #(spec/gen boolean?)
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::text
   (st/spec
-    {:type                :string
-     :spec                (spec/and string? #(not (str/blank? %)))
-     :description         "A non-empty string"
-     :json-schema/example "Used to impart a mild, zesty flavor."}))
+   {:type                  :string
+    :spec                  (spec/and string? #(not (str/blank? %)))
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string"
+    :json-schema/example   "Used to impart a mild, zesty flavor."}))
 
 
 (spec/def ::version
   (st/spec
-    {:type                :long
-     :spec                #(= 1 %)
-     :gen                 #(spec/gen #{1})
-     :description         "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists."
-     :json-schema/example "1"}))
+   {:type                  :long
+    :spec                  #(= 1 %)
+    impl/beer-xml-type-key impl/beer-xml-integer
+    :gen                   #(spec/gen #{1})
+    :description           "An integer representing the version of the BeerXML standard implemented in a given record. Currently, only 1 exists."
+    :json-schema/example   "1"}))
 
 
 (spec/def ::name
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string representing the name of the ingredient."
-     :json-schema/example "Citra"}))
+    {:type                   :string
+     :spec                   ::text
+     impl/beer-xml-type-key  impl/beer-xml-text
+     :description            "A non-empty string representing the name of the ingredient."
+     :json-schema/example    "Citra"}))
 
 
 (spec/def ::amount
   (st/spec
-    {:type                :double
-     :spec                ::kilogram
-     :description         "A ::kilogram value representing the amount of a particular ingredient."
-     :json-schema/example "12.5"}))
+    {:type                   :double
+     :spec                   ::kilogram
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key [impl/beer-xml-kilogram impl/beer-xml-liter]
+     :description            (impl/multiline
+                              "A value representing the amount of a particular ingredient."
+                              "When measuring weight, this is in kilograms."
+                              "When measuring volume, this is in liters.")
+     :json-schema/example    "12.5"}))
 
 
 (spec/def ::notes
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string representing any notes about the subject."
-     :json-schema/example "A wonderful, zesty aroma"}))
+    {:type                  :string
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::text
+     :description           "A non-empty string representing any notes about the subject."
+     :json-schema/example   "A wonderful, zesty aroma"}))
 
 
 (spec/def ::origin
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string denoting the place of origin for a particular ingredient."
-     :json-schema/example "Nice, France"}))
+    {:type                  :string
+     :spec                  ::text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the place of origin for a particular ingredient."
+     :json-schema/example   "Nice, France"}))
 
 
 (spec/def ::substitutes
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string denoting ingredients with me bay used in place of those denoted in the record."
-     :json-schema/example "Citra or Sorachi"}))
+    {:type                  :string
+     :spec                  ::text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting ingredients with me bay used in place of those denoted in the record."
+     :json-schema/example   "Citra or Sorachi"}))
 
 
 (spec/def ::amount-is-weight
   (st/spec
-    {:type                :boolean
-     :spec                ::boolean
-     :description         (impl/multiline
-                            "A boolean representing if the amount of the substance is measured in kilograms."
-                            "When absent, assume false and that the amount of substance is measured in liters.")
-     :json-schema/example "false"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+    {:type                  :boolean
+     :spec                  ::boolean
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline
+                              "A boolean representing if the amount of the substance is measured in kilograms."
+                              "When absent, assume false and that the amount of substance is measured in liters.")
+     :json-schema/example   "false"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::display-amount
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units."
-     :json-schema/example "100 g"}))
+    {:type                  :string
+     :spec                  ::text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the amount of the ingredient in a recipe formatted for display in arbitrary units."
+     :json-schema/example   "100 g"}))
 
 
 (spec/def ::inventory
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units."
-     :json-schema/example "100 lbs"}))
+    {:type                  :string
+     :spec                  ::text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the amount of the ingredient in inventory formatted for display in arbitrary units."
+     :json-schema/example   "100 lbs"}))
 
 
 (spec/def ::display-time
   (st/spec
-    {:type                :string
-     :spec                ::text
-     :description         "A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units."
-     :json-schema/example "10 days"}))
+    {:type                  :string
+     :spec                  ::text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for an amount of time formatted for display in arbitrary units."
+     :json-schema/example   "10 days"}))

--- a/src/common_beer_format/recipes.cljc
+++ b/src/common_beer_format/recipes.cljc
@@ -347,330 +347,330 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  recipe-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen recipe-types)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the type of recipe."
-                            (impl/set->description recipe-types)
-                            ""
-                            "- All Grain: A recipe that uses only malted grains."
-                            "- Partial Mash: A recipe that uses a combination of malted grains and malt extract."
-                            "- Extract: A recipe that uses only malt extract.")
-    :json-schema/example   "All Grain"}))
+    {:type                  :string
+     :spec                  recipe-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen recipe-types)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the type of recipe."
+                              (impl/set->description recipe-types)
+                              ""
+                              "- All Grain: A recipe that uses only malted grains."
+                              "- Partial Mash: A recipe that uses a combination of malted grains and malt extract."
+                              "- Extract: A recipe that uses only malt extract.")
+     :json-schema/example   "All Grain"}))
 
 
 (spec/def ::brewer
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting the name of the brewer."
-    :json-schema/example   "Nick A. Nichols"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the name of the brewer."
+     :json-schema/example   "Nick A. Nichols"}))
 
 
 (spec/def ::batch-size
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the target final volume of recipe."
-    :json-schema/example    "5.8"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the target final volume of recipe."
+     :json-schema/example    "5.8"}))
 
 
 (spec/def ::boil-size
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/liter
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-liter
-    :description            "A non-negative IEEE-754 floating point number representing the starting volume of the wort."
-    :json-schema/example    "7.5"}))
+    {:type                   :double
+     :spec                   ::prim/liter
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-liter
+     :description            "A non-negative IEEE-754 floating point number representing the starting volume of the wort."
+     :json-schema/example    "7.5"}))
 
 
 (spec/def ::boil-time
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/minute
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-minute
-    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort."
-    :json-schema/example    "45.0"}))
+    {:type                   :double
+     :spec                   ::prim/minute
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-minute
+     :description            "A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort."
+     :json-schema/example    "45.0"}))
 
 
 (spec/def ::asst-brewer
   (st/spec
-   {:type                  :string
-    impl/display-name-key  "Assistant Brewer"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :spec                  ::prim/text
-    :description           "A non-empty string denoting the name of the assistant brewer."
-    :json-schema/example   "Dariusz R. Jakubowski"}))
+    {:type                  :string
+     impl/display-name-key  "Assistant Brewer"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :spec                  ::prim/text
+     :description           "A non-empty string denoting the name of the assistant brewer."
+     :json-schema/example   "Dariusz R. Jakubowski"}))
 
 
 (spec/def ::efficiency
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer."
-    :json-schema/example   "85.6"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer."
+     :json-schema/example   "85.6"}))
 
 
 (spec/def ::taste-notes
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting any tasting notes."
-    :json-schema/example   "A nice, full body and intense mouthfeel"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting any tasting notes."
+     :json-schema/example   "A nice, full body and intense mouthfeel"}))
 
 
 (spec/def ::taste-rating
   (st/spec
-   {:type                  :double
-    :spec                  number?
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-double-generator
-    :description           "An IEEE-754 floating point number representing the tasting score of the beer."
-    :json-schema/example   "100.0"}))
+    {:type                  :double
+     :spec                  number?
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-double-generator
+     :description           "An IEEE-754 floating point number representing the tasting score of the beer."
+     :json-schema/example   "100.0"}))
 
 
 (spec/def ::og
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/specific-gravity
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-specific-gravity
-    impl/display-name-key   "Original Gravity"
-    :description            "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
-    :json-schema/example    "1.060"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     impl/display-name-key   "Original Gravity"
+     :description            "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
+     :json-schema/example    "1.060"}))
 
 
 (spec/def ::fg
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/specific-gravity
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-specific-gravity
-    impl/display-name-key   "Final Gravity"
-    :description            "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
-    :json-schema/example    "1.048"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     impl/display-name-key   "Final Gravity"
+     :description            "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
+     :json-schema/example    "1.048"}))
 
 
 (spec/def ::fermentation-stages
   (st/spec
-   {:type                  :long
-    :spec                  (spec/and integer? pos?)
-    impl/beer-xml-type-key impl/beer-xml-integer
-    :description           "An integer representing the number of fermentation stages in the recipe."
-    :json-schema/example   "2"}))
+    {:type                  :long
+     :spec                  (spec/and integer? pos?)
+     impl/beer-xml-type-key impl/beer-xml-integer
+     :description           "An integer representing the number of fermentation stages in the recipe."
+     :json-schema/example   "2"}))
 
 
 (spec/def ::primary-age
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-day
-    :gen                    impl/real-positive-double-generator
-    :description            "A positive IEEE-754 floating point number representing the number of days spent in primary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-day
+     :gen                    impl/real-positive-double-generator
+     :description            "A positive IEEE-754 floating point number representing the number of days spent in primary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::primary-temp
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/degrees-celsius
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    impl/display-name-key   "Primary Temperature"
-    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     impl/display-name-key   "Primary Temperature"
+     :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::secondary-age
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-day
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-day
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::secondary-temp
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/degrees-celsius
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    impl/display-name-key   "Secondary Temperature"
-    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     impl/display-name-key   "Secondary Temperature"
+     :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::tertiary-age
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-day
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-day
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::tertiary-temp
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/degrees-celsius
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    impl/display-name-key   "Tertiary Temperature"
-    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     impl/display-name-key   "Tertiary Temperature"
+     :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::age
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-day
-    :gen                    impl/real-positive-double-generator
-    :description            "A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-day
+     :gen                    impl/real-positive-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::age-temp
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/degrees-celsius
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    impl/display-name-key   "Aging Temperature"
-    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     impl/display-name-key   "Aging Temperature"
+     :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::date
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           (impl/multiline
-                            "A non-empty string denoting the display date the recipe was created on."
-                            "Intentionally implemented as a string type to match BeerXML spec.")
-    :json-schema/example   "2020/05/06"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           (impl/multiline
+                              "A non-empty string denoting the display date the recipe was created on."
+                              "Intentionally implemented as a string type to match BeerXML spec.")
+     :json-schema/example   "2020/05/06"}))
 
 
 (spec/def ::carbonation
   (st/spec
-   {:type                   :double
-    :spec                   number?
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-volumes-of-co2
-    :gen                    impl/real-double-generator
-    :description            "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2."
-    :json-schema/example    "1.5"}))
+    {:type                   :double
+     :spec                   number?
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-volumes-of-co2
+     :gen                    impl/real-double-generator
+     :description            "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2."
+     :json-schema/example    "1.5"}))
 
 
 (spec/def ::forced-carbonation
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline
-                            "A boolean representing if this batch was force carbonated with CO2 pressure."
-                            "When absent, assume false.")
-    :json-schema/example   "false"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline
+                              "A boolean representing if this batch was force carbonated with CO2 pressure."
+                              "When absent, assume false.")
+     :json-schema/example   "false"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::priming-sugar-name
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting the name of the priming agent used to carbonate the beer."
-    :json-schema/example   "Corn Sugar"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the name of the priming agent used to carbonate the beer."
+     :json-schema/example   "Corn Sugar"}))
 
 
 (spec/def ::carbonation-temp
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/degrees-celsius
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
-    :description            "An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation."
-    :json-schema/example    "12.0"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :description            "An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation."
+     :json-schema/example    "12.0"}))
 
 
 (spec/def ::priming-sugar-equiv
   (st/spec
-   {:type                  :double
-    :spec                  number?
-    impl/display-name-key  "Priming Sugar Equivalent"
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-double-generator
-    :description           "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
-    :json-schema/example   "1.5"}))
+    {:type                  :double
+     :spec                  number?
+     impl/display-name-key  "Priming Sugar Equivalent"
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-double-generator
+     :description           "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
+     :json-schema/example   "1.5"}))
 
 
 (spec/def ::keg-priming-factor
   (st/spec
-   {:type                  :double
-    :spec                  number?
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :gen                   impl/real-double-generator
-    :description           "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
-    :json-schema/example   "1.5"}))
+    {:type                  :double
+     :spec                  number?
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-double-generator
+     :description           "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
+     :json-schema/example   "1.5"}))
 
 
 (spec/def ::est-og
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    impl/display-name-key  "Estimated Original Gravity"
-    :description           "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
-    :json-schema/example   "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     impl/display-name-key  "Estimated Original Gravity"
+     :description           "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::est-fg
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Estimated Final Gravity"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
-    :json-schema/example   "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Estimated Final Gravity"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::est-color
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Estimated Color"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string describing the calculated color formatted for display in arbitrary units."
-    :json-schema/example   "30SRM"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Estimated Color"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string describing the calculated color formatted for display in arbitrary units."
+     :json-schema/example   "30SRM"}))
 
 
 (spec/def ::ibu
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/non-negative-number
-    impl/display-name-key   "International Bitterness Units"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-ibu
-    :gen                    impl/real-positive-double-generator
-    :description            "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
-    :json-schema/example    "40"}))
+    {:type                   :double
+     :spec                   ::prim/non-negative-number
+     impl/display-name-key   "International Bitterness Units"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-ibu
+     :gen                    impl/real-positive-double-generator
+     :description            "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
+     :json-schema/example    "40"}))
 
 
 (def rager
@@ -697,125 +697,125 @@
 
 (spec/def ::ibu-method
   (st/spec
-   {:type                  :string
-    :spec                  ibu-method-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen ibu-method-types)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the method of calculation used derive the IBUs."
-                            (impl/set->description ibu-method-types)
-                            ""
-                            "- Garetz: The Garetz method of IBU calculation."
-                            "- Rager: The Rager method of IBU calculation."
-                            "- Tinseth: The Tinseth method of IBU calculation.")
-    :json-schema/example   "Garetz"}))
+    {:type                  :string
+     :spec                  ibu-method-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen ibu-method-types)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the method of calculation used derive the IBUs."
+                              (impl/set->description ibu-method-types)
+                              ""
+                              "- Garetz: The Garetz method of IBU calculation."
+                              "- Rager: The Rager method of IBU calculation."
+                              "- Tinseth: The Tinseth method of IBU calculation.")
+     :json-schema/example   "Garetz"}))
 
 
 (spec/def ::est-abv
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/percent
-    impl/display-name-key   "Estimated ABV"
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-abv
-    :description            "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
-    :json-schema/example    "40.1"}))
+    {:type                   :double
+     :spec                   ::prim/percent
+     impl/display-name-key   "Estimated ABV"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-abv
+     :description            "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
+     :json-schema/example    "40.1"}))
 
 
 (spec/def ::abv
   (st/spec
-   {:type                   :double
-    :spec                   ::prim/percent
-    impl/beer-xml-type-key  impl/beer-xml-floating-point
-    impl/beer-xml-units-key impl/beer-xml-abv
-    :description            "A non-negative IEEE-754 floating point number representing the actual ABV for the recipe."
-    :json-schema/example    "40.2"}))
+    {:type                   :double
+     :spec                   ::prim/percent
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-abv
+     :description            "A non-negative IEEE-754 floating point number representing the actual ABV for the recipe."
+     :json-schema/example    "40.2"}))
 
 
 (spec/def ::actual-efficiency
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-floating-point
-    :description           "A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities."
-    :json-schema/example   "40.3"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :description           "A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities."
+     :json-schema/example   "40.3"}))
 
 
 (spec/def ::calories
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string describing the number of dietary calories per serving of this recipe."
-    :json-schema/example   "180 Cal / pint"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string describing the number of dietary calories per serving of this recipe."
+     :json-schema/example   "180 Cal / pint"}))
 
 
 (spec/def ::display-boil-size
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
-    :json-schema/example   "5.0 gallons"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
+     :json-schema/example   "5.0 gallons"}))
 
 
 (spec/def ::display-batch-size
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
-    :json-schema/example   "4.5 gallons"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
+     :json-schema/example   "4.5 gallons"}))
 
 
 (spec/def ::display-og
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Display Original Gravity"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
-    :json-schema/example   "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Original Gravity"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-fg
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Display Final Gravity"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units."
-    :json-schema/example   "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Final Gravity"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-primary-temp
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Display Primary Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
-    :json-schema/example   "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Primary Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::display-secondary-temp
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Display Secondary Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
-    :json-schema/example   "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Secondary Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::display-tertiary-temp
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/display-name-key  "Display Tertiary Temperature"
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
-    :json-schema/example   "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Tertiary Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::display-age-temp

--- a/src/common_beer_format/recipes.cljc
+++ b/src/common_beer_format/recipes.cljc
@@ -39,9 +39,9 @@
 
 (def type
   "A string representing the type of recipe.
-   
+
    Currenltly, BeerXML support the following types:
-   
+
    - `all-grain`: A recipe that uses only malted grains.
    - `partial-mash`: A recipe that uses a combination of malted grains and malt extract.
    - `extract`: A recipe that uses only malt extract."
@@ -245,9 +245,9 @@
 
 (def ibu-method
   "A string representing the method used to calculate the bitterness of the beer.
-   
+
    Currently, the following methods are supported:
-   
+
    - Tinseth: Tinseth's method for calculating bitterness.
    - Rager: Rager's method for calculating bitterness.
    - Garetz: Garetz's method for calculating bitterness."
@@ -524,7 +524,7 @@
 
 
 (spec/def ::date
-  ;; 
+  ;;
   (st/spec
     {:type                :string
      :spec                ::prim/text
@@ -697,7 +697,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-permentation volume formatted for display in arbitrary units."
+     :description         "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
      :json-schema/example "4.5 gallons"}))
 
 
@@ -705,7 +705,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-permentation gravity formatted for display in arbitrary units."
+     :description         "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
      :json-schema/example "1.050sg"}))
 
 

--- a/src/common_beer_format/recipes.cljc
+++ b/src/common_beer_format/recipes.cljc
@@ -2,7 +2,6 @@
   "The definition of a recipe record used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.equipment :as cbf-equipment]
             [common-beer-format.fermentables :as cbf-fermentables]
             [common-beer-format.hops :as cbf-hops]
@@ -326,17 +325,17 @@
 
 (def extract
   "A recipe type that exclusively uses malt extracts and sugars."
-  "extract")
+  "Extract")
 
 
 (def partial-mash
   "A recipe type that uses a combination of malt extracts and sugars and malted grains."
-  "partial mash")
+  "Partial Mash")
 
 
 (def all-grain
   "A recipe type that exclusively uses malted grains."
-  "all grain")
+  "All Grain")
 
 
 (def recipe-types
@@ -348,14 +347,17 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? recipe-types (str/lower-case %)))
-     :gen                 #(spec/gen recipe-types)
-     :description         (impl/multiline "A case-insensitive string representing the type of recipe."
-                                          (impl/set->description recipe-types))
-     :json-schema/example "All Grain"}))
+   {:type                :string
+    :spec                recipe-types
+    :gen                 #(spec/gen recipe-types)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the type of recipe."
+                          (impl/set->description recipe-types)
+                          ""
+                          "- All Grain: A recipe that uses only malted grains."
+                          "- Partial Mash: A recipe that uses a combination of malted grains and malt extract."
+                          "- Extract: A recipe that uses only malt extract.")
+    :json-schema/example "All Grain"}))
 
 
 (spec/def ::brewer
@@ -392,10 +394,11 @@
 
 (spec/def ::asst-brewer
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the name of the assistant brewer."
-     :json-schema/example "Dariusz R. Jakubowski"}))
+    {:type                 :string
+     impl/display-name-key "Assistant Brewer"
+     :spec                 ::prim/text
+     :description          "A non-empty string denoting the name of the assistant brewer."
+     :json-schema/example  "Dariusz R. Jakubowski"}))
 
 
 (spec/def ::efficiency
@@ -425,18 +428,20 @@
 
 (spec/def ::og
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
-     :json-schema/example "1.060"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Original Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
+     :json-schema/example  "1.060"}))
 
 
 (spec/def ::fg
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
-     :json-schema/example "1.048"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Final Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
+     :json-schema/example  "1.048"}))
 
 
 (spec/def ::fermentation-stages
@@ -458,10 +463,11 @@
 
 (spec/def ::primary-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperaure in degrees Celsius for primary fermentation."
-     :json-schema/example "12.0"}))
+    {:type                 :double
+     :spec                 ::prim/degrees-celsius
+     impl/display-name-key "Primary Temperature"
+     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation."
+     :json-schema/example  "12.0"}))
 
 
 (spec/def ::secondary-age
@@ -475,10 +481,11 @@
 
 (spec/def ::secondary-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperaure in degrees Celsius for secondary fermentation."
-     :json-schema/example "12.0"}))
+    {:type                 :double
+     :spec                 ::prim/degrees-celsius
+     impl/display-name-key "Secondary Temperature"
+     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation."
+     :json-schema/example  "12.0"}))
 
 
 (spec/def ::tertiary-age
@@ -492,10 +499,11 @@
 
 (spec/def ::tertiary-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperaure in degrees Celsius for tertiary fermentation."
-     :json-schema/example "12.0"}))
+    {:type                 :double
+     :spec                 ::prim/degrees-celsius
+     impl/display-name-key "Tertiary Temperature"
+     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation."
+     :json-schema/example  "12.0"}))
 
 
 (spec/def ::age
@@ -507,30 +515,23 @@
      :json-schema/example "12.0"}))
 
 
-(spec/def ::age
-  (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer."
-     :json-schema/example "12.0"}))
-
-
 (spec/def ::age-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "A non-negative IEEE-754 floating point number representing the temperaure in degrees Celsius for bottle aging."
-     :json-schema/example "12.0"}))
+    {:type                 :double
+     :spec                 ::prim/degrees-celsius
+     impl/display-name-key "Aging Temperature"
+     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging."
+     :json-schema/example  "12.0"}))
 
 
 (spec/def ::date
-  ;;
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         (impl/multiline "A non-empty string denoting the display date the recipe was created on."
-                                          "Intentionally implemented as a string type to match BeerXML spec.")
-     :json-schema/example "2020/05/06"}))
+   {:type                :string
+    :spec                ::prim/text
+    :description         (impl/multiline
+                          "A non-empty string denoting the display date the recipe was created on."
+                          "Intentionally implemented as a string type to match BeerXML spec.")
+    :json-schema/example "2020/05/06"}))
 
 
 (spec/def ::carbonation
@@ -544,12 +545,13 @@
 
 (spec/def ::forced-carbonation
   (st/spec
-    {:spec                ::prim/boolean
-     :description         (impl/multiline "A boolean representing if this batch was force carbonated with CO2 pressure."
-                                          "When absent, assume false.")
-     :json-schema/example "false"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+   {:spec                ::prim/boolean
+    :description         (impl/multiline
+                          "A boolean representing if this batch was force carbonated with CO2 pressure."
+                          "When absent, assume false.")
+    :json-schema/example "false"
+    :decode/string       impl/decode-boolean
+    :encode/string       impl/encode-boolean}))
 
 
 (spec/def ::priming-sugar-name
@@ -564,17 +566,18 @@
   (st/spec
     {:type                :double
      :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the temperaure in degrees Celsius for either bottling or forced carbonation."
+     :description         "An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation."
      :json-schema/example "12.0"}))
 
 
 (spec/def ::priming-sugar-equiv
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
-     :json-schema/example "1.5"}))
+    {:type                 :double
+     :spec                 number?
+     impl/display-name-key "Priming Sugar Equivalent"
+     :gen                  impl/real-double-generator
+     :description          "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
+     :json-schema/example  "1.5"}))
 
 
 (spec/def ::keg-priming-factor
@@ -588,50 +591,54 @@
 
 (spec/def ::est-og
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Estimated Original Gravity"
+     :description          "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::est-fg
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Estimated Final Gravity"
+     :description          "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::est-color
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string describing the calculated color formatted for display in arbitrary units."
-     :json-schema/example "30SRM"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Estimated Color"
+     :description          "A non-empty string describing the calculated color formatted for display in arbitrary units."
+     :json-schema/example  "30SRM"}))
 
 
 (spec/def ::ibu
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
-     :json-schema/example "40"}))
+    {:type                 :double
+     :spec                 (spec/and number? #(not (neg? %)))
+     impl/display-name-key "International Bitterness Units"
+     :gen                  impl/real-positive-double-generator
+     :description          "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
+     :json-schema/example  "40"}))
 
 
 (def rager
   "The Rager method of IBU calculation."
-  "rager")
+  "Rager")
 
 
 (def tinseth
   "The Tinseth method of IBU calculation."
-  "tinseth")
+  "Tinseth")
 
 
 (def garetz
   "The Garetz method of IBU calculation."
-  "garetz")
+  "Garetz")
 
 
 (def ibu-method-types
@@ -643,22 +650,26 @@
 
 (spec/def ::ibu-method
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? ibu-method-types (str/lower-case %)))
-     :gen                 #(spec/gen ibu-method-types)
-     :description         (impl/multiline "A case-insensitive string representing the method of calculation used derive the IBUs."
-                                          (impl/set->description ibu-method-types))
-     :json-schema/example "Garetz"}))
+   {:type                :string
+    :spec                ibu-method-types
+    :gen                 #(spec/gen ibu-method-types)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the method of calculation used derive the IBUs."
+                          (impl/set->description ibu-method-types)
+                          ""
+                          "- Garetz: The Garetz method of IBU calculation."
+                          "- Rager: The Rager method of IBU calculation."
+                          "- Tinseth: The Tinseth method of IBU calculation.")
+    :json-schema/example "Garetz"}))
 
 
 (spec/def ::est-abv
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
-     :json-schema/example "40"}))
+    {:type                 :double
+     :spec                 ::prim/percent
+     impl/display-name-key "Estimated ABV"
+     :description          "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
+     :json-schema/example  "40"}))
 
 
 (spec/def ::abv
@@ -703,50 +714,56 @@
 
 (spec/def ::display-og
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Original Gravity"
+     :description          "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::display-fg
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the post-permentation gravity formatted for display in arbitrary units."
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Final Gravity"
+     :description          "A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::display-primary-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Primary Temperature"
+     :description          "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::display-secondary-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Secondary Temperature"
+     :description          "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::display-tertiary-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Tertiary Temperature"
+     :description          "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::display-age-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units."
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Aging Temperature"
+     :description          "A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::carbonation-used
@@ -759,10 +776,11 @@
 
 (spec/def ::display-carb-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units."
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Carbonation Temperature"
+     :description          "A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::recipe
@@ -830,15 +848,16 @@
 
 (spec/def ::recipe-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::recipe record wrapped in a ::recipes map."
-     :spec        (spec/keys :req-un [::recipe])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::recipe` record wrapped in a `:recipes` map."
+     :spec                 (spec/keys :req-un [::recipe])}))
 
 
 (spec/def ::recipes
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::recipe records."
+     :description   "A vector of valid `::recipe` records."
      :spec          (spec/coll-of ::recipe-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::recipe-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::recipe-wrapper %2)}))
@@ -846,6 +865,7 @@
 
 (spec/def ::recipes-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::recipes-wrapper record."
-     :spec        (spec/keys :req-un [::recipes])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::recipes-wrapper` record."
+     :spec                 (spec/keys :req-un [::recipes])}))

--- a/src/common_beer_format/recipes.cljc
+++ b/src/common_beer_format/recipes.cljc
@@ -347,283 +347,330 @@
 
 (spec/def ::type
   (st/spec
-   {:type                :string
-    :spec                recipe-types
-    :gen                 #(spec/gen recipe-types)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the type of recipe."
-                          (impl/set->description recipe-types)
-                          ""
-                          "- All Grain: A recipe that uses only malted grains."
-                          "- Partial Mash: A recipe that uses a combination of malted grains and malt extract."
-                          "- Extract: A recipe that uses only malt extract.")
-    :json-schema/example "All Grain"}))
+   {:type                  :string
+    :spec                  recipe-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen recipe-types)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the type of recipe."
+                            (impl/set->description recipe-types)
+                            ""
+                            "- All Grain: A recipe that uses only malted grains."
+                            "- Partial Mash: A recipe that uses a combination of malted grains and malt extract."
+                            "- Extract: A recipe that uses only malt extract.")
+    :json-schema/example   "All Grain"}))
 
 
 (spec/def ::brewer
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the name of the brewer."
-     :json-schema/example "Nick A. Nichols"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting the name of the brewer."
+    :json-schema/example   "Nick A. Nichols"}))
 
 
 (spec/def ::batch-size
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the target final volume of recipe."
-     :json-schema/example "5.8"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the target final volume of recipe."
+    :json-schema/example    "5.8"}))
 
 
 (spec/def ::boil-size
   (st/spec
-    {:type                :double
-     :spec                ::prim/liter
-     :description         "A non-negative IEEE-754 floating point number representing the starting volume of the wort."
-     :json-schema/example "7.5"}))
+   {:type                   :double
+    :spec                   ::prim/liter
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-liter
+    :description            "A non-negative IEEE-754 floating point number representing the starting volume of the wort."
+    :json-schema/example    "7.5"}))
 
 
 (spec/def ::boil-time
   (st/spec
-    {:type                :double
-     :spec                ::prim/minute
-     :description         "A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort."
-     :json-schema/example "45.0"}))
+   {:type                   :double
+    :spec                   ::prim/minute
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-minute
+    :description            "A non-negative IEEE-754 floating point number representing the time in minutes to boil the wort."
+    :json-schema/example    "45.0"}))
 
 
 (spec/def ::asst-brewer
   (st/spec
-    {:type                 :string
-     impl/display-name-key "Assistant Brewer"
-     :spec                 ::prim/text
-     :description          "A non-empty string denoting the name of the assistant brewer."
-     :json-schema/example  "Dariusz R. Jakubowski"}))
+   {:type                  :string
+    impl/display-name-key  "Assistant Brewer"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :spec                  ::prim/text
+    :description           "A non-empty string denoting the name of the assistant brewer."
+    :json-schema/example   "Dariusz R. Jakubowski"}))
 
 
 (spec/def ::efficiency
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer."
-     :json-schema/example "85.6"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A non-negative IEEE-754 floating point number representing the percent brewhouse efficiency to be used for estimating the starting gravity of the beer."
+    :json-schema/example   "85.6"}))
 
 
 (spec/def ::taste-notes
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting any tasting notes."
-     :json-schema/example "A nice, full body and intense mouthfeel"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting any tasting notes."
+    :json-schema/example   "A nice, full body and intense mouthfeel"}))
 
 
 (spec/def ::taste-rating
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing the tasting score of the beer."
-     :json-schema/example "100.0"}))
+   {:type                  :double
+    :spec                  number?
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-double-generator
+    :description           "An IEEE-754 floating point number representing the tasting score of the beer."
+    :json-schema/example   "100.0"}))
 
 
 (spec/def ::og
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Original Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
-     :json-schema/example  "1.060"}))
+   {:type                   :double
+    :spec                   ::prim/specific-gravity
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-specific-gravity
+    impl/display-name-key   "Original Gravity"
+    :description            "A non-negative IEEE-754 floating point number representing the pre-fermentation specific gravity of the recipe."
+    :json-schema/example    "1.060"}))
 
 
 (spec/def ::fg
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Final Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
-     :json-schema/example  "1.048"}))
+   {:type                   :double
+    :spec                   ::prim/specific-gravity
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-specific-gravity
+    impl/display-name-key   "Final Gravity"
+    :description            "A non-negative IEEE-754 floating point number representing the post-fermentation specific gravity of the recipe."
+    :json-schema/example    "1.048"}))
 
 
 (spec/def ::fermentation-stages
   (st/spec
-    {:type                :long
-     :spec                (spec/and integer? pos?)
-     :description         "An integer representing the number of fermentation stages in the recipe."
-     :json-schema/example "2"}))
+   {:type                  :long
+    :spec                  (spec/and integer? pos?)
+    impl/beer-xml-type-key impl/beer-xml-integer
+    :description           "An integer representing the number of fermentation stages in the recipe."
+    :json-schema/example   "2"}))
 
 
 (spec/def ::primary-age
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the number of days spent in primary fermentation."
-     :json-schema/example "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-day
+    :gen                    impl/real-positive-double-generator
+    :description            "A positive IEEE-754 floating point number representing the number of days spent in primary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::primary-temp
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/degrees-celsius
-     impl/display-name-key "Primary Temperature"
-     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation."
-     :json-schema/example  "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/degrees-celsius
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    impl/display-name-key   "Primary Temperature"
+    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for primary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::secondary-age
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation."
-     :json-schema/example "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-day
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing the number of days spent in secondary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::secondary-temp
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/degrees-celsius
-     impl/display-name-key "Secondary Temperature"
-     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation."
-     :json-schema/example  "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/degrees-celsius
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    impl/display-name-key   "Secondary Temperature"
+    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for secondary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::tertiary-age
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation."
-     :json-schema/example "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-day
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing the number of days spent in tertiary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::tertiary-temp
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/degrees-celsius
-     impl/display-name-key "Tertiary Temperature"
-     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation."
-     :json-schema/example  "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/degrees-celsius
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    impl/display-name-key   "Tertiary Temperature"
+    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for tertiary fermentation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::age
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? #(not (neg? %)))
-     :gen                 impl/real-positive-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer."
-     :json-schema/example "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/non-negative-number
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-day
+    :gen                    impl/real-positive-double-generator
+    :description            "A non-negative IEEE-754 floating point number representing the number of days to bottle age the beer."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::age-temp
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/degrees-celsius
-     impl/display-name-key "Aging Temperature"
-     :description          "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging."
-     :json-schema/example  "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/degrees-celsius
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    impl/display-name-key   "Aging Temperature"
+    :description            "A non-negative IEEE-754 floating point number representing the temperature in degrees Celsius for bottle aging."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::date
   (st/spec
-   {:type                :string
-    :spec                ::prim/text
-    :description         (impl/multiline
-                          "A non-empty string denoting the display date the recipe was created on."
-                          "Intentionally implemented as a string type to match BeerXML spec.")
-    :json-schema/example "2020/05/06"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           (impl/multiline
+                            "A non-empty string denoting the display date the recipe was created on."
+                            "Intentionally implemented as a string type to match BeerXML spec.")
+    :json-schema/example   "2020/05/06"}))
 
 
 (spec/def ::carbonation
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2."
-     :json-schema/example "1.5"}))
+   {:type                   :double
+    :spec                   number?
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-volumes-of-co2
+    :gen                    impl/real-double-generator
+    :description            "An IEEE-754 floating point number representing the carbonation for this recipe in volumes of CO2."
+    :json-schema/example    "1.5"}))
 
 
 (spec/def ::forced-carbonation
   (st/spec
-   {:spec                ::prim/boolean
-    :description         (impl/multiline
-                          "A boolean representing if this batch was force carbonated with CO2 pressure."
-                          "When absent, assume false.")
-    :json-schema/example "false"
-    :decode/string       impl/decode-boolean
-    :encode/string       impl/encode-boolean}))
+   {:spec                  ::prim/boolean
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline
+                            "A boolean representing if this batch was force carbonated with CO2 pressure."
+                            "When absent, assume false.")
+    :json-schema/example   "false"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::priming-sugar-name
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the name of the priming agent used to carbonate the beer."
-     :json-schema/example "Corn Sugar"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting the name of the priming agent used to carbonate the beer."
+    :json-schema/example   "Corn Sugar"}))
 
 
 (spec/def ::carbonation-temp
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation."
-     :json-schema/example "12.0"}))
+   {:type                   :double
+    :spec                   ::prim/degrees-celsius
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+    :description            "An IEEE-754 floating point number representing the temperature in degrees Celsius for either bottling or forced carbonation."
+    :json-schema/example    "12.0"}))
 
 
 (spec/def ::priming-sugar-equiv
   (st/spec
-    {:type                 :double
-     :spec                 number?
-     impl/display-name-key "Priming Sugar Equivalent"
-     :gen                  impl/real-double-generator
-     :description          "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
-     :json-schema/example  "1.5"}))
+   {:type                  :double
+    :spec                  number?
+    impl/display-name-key  "Priming Sugar Equivalent"
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-double-generator
+    :description           "An IEEE-754 floating point number representing the conversion factor to an equivalent amount of corn sugar."
+    :json-schema/example   "1.5"}))
 
 
 (spec/def ::keg-priming-factor
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
-     :json-schema/example "1.5"}))
+   {:type                  :double
+    :spec                  number?
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :gen                   impl/real-double-generator
+    :description           "An IEEE-754 floating point number representing the conversion factor of sugar needed to prime carbonation in large containers."
+    :json-schema/example   "1.5"}))
 
 
 (spec/def ::est-og
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Estimated Original Gravity"
-     :description          "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    impl/display-name-key  "Estimated Original Gravity"
+    :description           "A non-empty string describing the calculated estimated original gravity formatted for display in arbitrary units."
+    :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::est-fg
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Estimated Final Gravity"
-     :description          "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Estimated Final Gravity"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string describing the calculated estimated final gravity formatted for display in arbitrary units."
+    :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::est-color
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Estimated Color"
-     :description          "A non-empty string describing the calculated color formatted for display in arbitrary units."
-     :json-schema/example  "30SRM"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Estimated Color"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string describing the calculated color formatted for display in arbitrary units."
+    :json-schema/example   "30SRM"}))
 
 
 (spec/def ::ibu
   (st/spec
-    {:type                 :double
-     :spec                 (spec/and number? #(not (neg? %)))
-     impl/display-name-key "International Bitterness Units"
-     :gen                  impl/real-positive-double-generator
-     :description          "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
-     :json-schema/example  "40"}))
+   {:type                   :double
+    :spec                   ::prim/non-negative-number
+    impl/display-name-key   "International Bitterness Units"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-ibu
+    :gen                    impl/real-positive-double-generator
+    :description            "A positive IEEE-754 floating point number representing the bitterness in IBUs for the recipe."
+    :json-schema/example    "40"}))
 
 
 (def rager
@@ -650,137 +697,154 @@
 
 (spec/def ::ibu-method
   (st/spec
-   {:type                :string
-    :spec                ibu-method-types
-    :gen                 #(spec/gen ibu-method-types)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the method of calculation used derive the IBUs."
-                          (impl/set->description ibu-method-types)
-                          ""
-                          "- Garetz: The Garetz method of IBU calculation."
-                          "- Rager: The Rager method of IBU calculation."
-                          "- Tinseth: The Tinseth method of IBU calculation.")
-    :json-schema/example "Garetz"}))
+   {:type                  :string
+    :spec                  ibu-method-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen ibu-method-types)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the method of calculation used derive the IBUs."
+                            (impl/set->description ibu-method-types)
+                            ""
+                            "- Garetz: The Garetz method of IBU calculation."
+                            "- Rager: The Rager method of IBU calculation."
+                            "- Tinseth: The Tinseth method of IBU calculation.")
+    :json-schema/example   "Garetz"}))
 
 
 (spec/def ::est-abv
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/percent
-     impl/display-name-key "Estimated ABV"
-     :description          "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
-     :json-schema/example  "40"}))
+   {:type                   :double
+    :spec                   ::prim/percent
+    impl/display-name-key   "Estimated ABV"
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-abv
+    :description            "A non-negative IEEE-754 floating point number representing the estimated ABV for the recipe."
+    :json-schema/example    "40.1"}))
 
 
 (spec/def ::abv
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the actual ABV for the recipe."
-     :json-schema/example "40"}))
+   {:type                   :double
+    :spec                   ::prim/percent
+    impl/beer-xml-type-key  impl/beer-xml-floating-point
+    impl/beer-xml-units-key impl/beer-xml-abv
+    :description            "A non-negative IEEE-754 floating point number representing the actual ABV for the recipe."
+    :json-schema/example    "40.2"}))
 
 
 (spec/def ::actual-efficiency
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities."
-     :json-schema/example "40"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-floating-point
+    :description           "A non-negative IEEE-754 floating point number representing the actual conversion efficiency between the measured final and original gravities."
+    :json-schema/example   "40.3"}))
 
 
 (spec/def ::calories
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string describing the number of dietary calories per serving of this recipe."
-     :json-schema/example "180 Cal / pint"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string describing the number of dietary calories per serving of this recipe."
+    :json-schema/example   "180 Cal / pint"}))
 
 
 (spec/def ::display-boil-size
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
-     :json-schema/example "5.0 gallons"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the pre-boil volume formatted for display in arbitrary units."
+    :json-schema/example   "5.0 gallons"}))
 
 
 (spec/def ::display-batch-size
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
-     :json-schema/example "4.5 gallons"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the pre-fermentation volume formatted for display in arbitrary units."
+    :json-schema/example   "4.5 gallons"}))
 
 
 (spec/def ::display-og
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Original Gravity"
-     :description          "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Display Original Gravity"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the pre-fermentation gravity formatted for display in arbitrary units."
+    :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-fg
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Final Gravity"
-     :description          "A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Display Final Gravity"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the post-fermentation gravity formatted for display in arbitrary units."
+    :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-primary-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Primary Temperature"
-     :description          "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Display Primary Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the temperature of the primary fermentation step formatted for display in arbitrary units."
+    :json-schema/example   "68F"}))
 
 
 (spec/def ::display-secondary-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Secondary Temperature"
-     :description          "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Display Secondary Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the temperature of the secondary fermentation step formatted for display in arbitrary units."
+    :json-schema/example   "68F"}))
 
 
 (spec/def ::display-tertiary-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Tertiary Temperature"
-     :description          "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/display-name-key  "Display Tertiary Temperature"
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting a display value for the temperature of the tertiary fermentation step formatted for display in arbitrary units."
+    :json-schema/example   "68F"}))
 
 
 (spec/def ::display-age-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Aging Temperature"
-     :description          "A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Aging Temperature"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the temperature of the aging step formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::carbonation-used
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the carbonation measures used formatted for display in arbitrary units."
-     :json-schema/example "Kegged at 1.36 atmospheres"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the carbonation measures used formatted for display in arbitrary units."
+     :json-schema/example   "Kegged at 1.36 atmospheres"}))
 
 
 (spec/def ::display-carb-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Carbonation Temperature"
-     :description          "A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     impl/display-name-key  "Display Carbonation Temperature"
+     :description           "A non-empty string denoting a display value for the temperature of the bottling step formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::recipe
@@ -848,10 +912,11 @@
 
 (spec/def ::recipe-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::recipe` record wrapped in a `:recipes` map."
-     :spec                 (spec/keys :req-un [::recipe])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::recipe` record wrapped in a `:recipes` map."
+     :spec                  (spec/keys :req-un [::recipe])}))
 
 
 (spec/def ::recipes
@@ -865,7 +930,8 @@
 
 (spec/def ::recipes-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::recipes-wrapper` record."
-     :spec                 (spec/keys :req-un [::recipes])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::recipes-wrapper` record."
+     :spec                  (spec/keys :req-un [::recipes])}))

--- a/src/common_beer_format/styles.cljc
+++ b/src/common_beer_format/styles.cljc
@@ -204,35 +204,39 @@
 
 (spec/def ::category
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the category this style belongs to."
-     :json-schema/example "American Lagers"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the category this style belongs to."
+     :json-schema/example   "American Lagers"}))
 
 
 (spec/def ::category-number
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         (impl/multiline "A non-empty string denoting the category number of this style."
-                                          "The category number is a string because it can be a letter followed by a number, e.g. 'A1' on some guides.")
-     :json-schema/example "1"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           (impl/multiline "A non-empty string denoting the category number of this style."
+                                            "The category number is a string because it can be a letter followed by a number, e.g. 'A1' on some guides.")
+     :json-schema/example   "1"}))
 
 
 (spec/def ::style-letter
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the letter used to denote the style or sub-style."
-     :json-schema/example "A"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the letter used to denote the style or sub-style."
+     :json-schema/example   "A"}))
 
 
 (spec/def ::style-guide
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the name of the style guide the style/category belongs to."
-     :json-schema/example "BJCP"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the name of the style guide the style/category belongs to."
+     :json-schema/example   "BJCP"}))
 
 
 (def lager
@@ -277,258 +281,298 @@
 
 (spec/def ::type
   (st/spec
-   {:type                :string
-    :spec                style-types
-    :gen                 #(spec/gen style-types)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the type of beverage the style dictates."
-                          (impl/set->description style-types)
-                          ""
-                          "- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish."
-                          "- Cider: A fermented beverage made from fruit and water."
-                          "- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
-                          "- Mead: A fermented beverage made from honey and water."
-                          "- Mixed: A beer style that blends two or more styles."
-                          "- Wheat: A beer made with a large proportion of wheat malt.")
-    :json-schema/example "Lager"}))
+   {:type                  :string
+    :spec                  style-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen style-types)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the type of beverage the style dictates."
+                            (impl/set->description style-types)
+                            ""
+                            "- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish."
+                            "- Cider: A fermented beverage made from fruit and water."
+                            "- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
+                            "- Mead: A fermented beverage made from honey and water."
+                            "- Mixed: A beer style that blends two or more styles."
+                            "- Wheat: A beer made with a large proportion of wheat malt.")
+    :json-schema/example   "Lager"}))
 
 
 (spec/def ::og-min
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Minimum Original Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style."
-     :json-schema/example  "1.048"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/display-name-key   "Minimum Original Gravity"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :description            "A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style."
+     :json-schema/example    "1.048"}))
 
 
 (spec/def ::og-max
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Maximum Original Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style."
-     :json-schema/example  "1.060"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/display-name-key   "Maximum Original Gravity"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :description            "A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style."
+     :json-schema/example    "1.060"}))
 
 
 (spec/def ::fg-min
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Minimum Final Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style."
-     :json-schema/example  "1.048"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/display-name-key   "Minimum Final Gravity"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :description            "A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style."
+     :json-schema/example    "1.048"}))
 
 
 (spec/def ::fg-max
   (st/spec
-    {:type                 :double
-     :spec                 ::prim/specific-gravity
-     impl/display-name-key "Maximum Final Gravity"
-     :description          "A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style."
-     :json-schema/example  "1.060"}))
+    {:type                   :double
+     :spec                   ::prim/specific-gravity
+     impl/display-name-key   "Maximum Final Gravity"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-specific-gravity
+     :description            "A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style."
+     :json-schema/example    "1.060"}))
 
 
 (spec/def ::ibu-min
   (st/spec
-    {:type                 :double
-     :spec                 number?
-     impl/display-name-key "Minimum International Bittering Units"
-     :gen                  impl/real-double-generator
-     :description          "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style."
-     :json-schema/example  "32"}))
+    {:type                   :double
+     :spec                   number?
+     impl/display-name-key   "Minimum International Bittering Units"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-ibu
+     :gen                    impl/real-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style."
+     :json-schema/example    "32"}))
 
 
 (spec/def ::ibu-max
   (st/spec
-    {:type                 :double
-     :spec                 number?
-     impl/display-name-key "Maximum International Bittering Units"
-     :gen                  impl/real-double-generator
-     :description          "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style."
-     :json-schema/example  "40"}))
+    {:type                   :double
+     :spec                   number?
+     impl/display-name-key   "Maximum International Bittering Units"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-ibu
+     :gen                    impl/real-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style."
+     :json-schema/example    "40"}))
 
 
 (spec/def ::color-min
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style."
-     :json-schema/example "32"}))
+    {:type                   :double
+     :spec                   number?
+     :gen                    impl/real-double-generator
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-srm
+     :description            "A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style."
+     :json-schema/example    "32"}))
 
 
 (spec/def ::color-max
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style."
-     :json-schema/example "40"}))
+    {:type                   :double
+     :spec                   number?
+     :gen                    impl/real-double-generator
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-srm
+     :description            "A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style."
+     :json-schema/example    "40"}))
 
 
 (spec/def ::carb-min
   (st/spec
-    {:type                 :double
-     :spec                 number?
-     impl/display-name-key "Minimum Carbonation"
-     :gen                  impl/real-double-generator
-     :description          "A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2."
-     :json-schema/example  "1.5"}))
+    {:type                   :double
+     :spec                   number?
+     impl/display-name-key   "Minimum Carbonation"
+     :gen                    impl/real-double-generator
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     impl/beer-xml-units-key impl/beer-xml-volumes-of-co2
+     :description            "A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2."
+     :json-schema/example    "1.5"}))
 
 
 (spec/def ::carb-max
   (st/spec
-    {:type                 :double
-     :spec                 number?
-     impl/display-name-key "Maximum Carbonation"
-     :gen                  impl/real-double-generator
-     :description          "A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2."
-     :json-schema/example  "2.2"}))
+    {:type                   :double
+     :spec                   number?
+     impl/display-name-key   "Maximum Carbonation"
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     impl/beer-xml-units-key impl/beer-xml-volumes-of-co2
+     :gen                    impl/real-double-generator
+     :description            "A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2."
+     :json-schema/example    "2.2"}))
 
 
 (spec/def ::abv-min
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style."
-     :json-schema/example "0.032"}))
+    {:type                   :double
+     :spec                   ::prim/percent
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     impl/beer-xml-units-key impl/beer-xml-abv
+     :description            "A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style."
+     :json-schema/example    "0.032"}))
 
 
 (spec/def ::abv-max
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style."
-     :json-schema/example "0.04"}))
+    {:type                   :double
+     :spec                   ::prim/percent
+     impl/beer-xml-type-key  impl/beer-xml-percentage
+     impl/beer-xml-units-key impl/beer-xml-abv
+     :description            "A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style."
+     :json-schema/example    "0.04"}))
 
 
 (spec/def ::profile
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the aroma and flavor profile of the style."
-     :json-schema/example "Full-bodied and dark."}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the aroma and flavor profile of the style."
+     :json-schema/example   "Full-bodied and dark."}))
 
 
 (spec/def ::ingredients
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the suggested ingredients for the style."
-     :json-schema/example "water, barley, and hops."}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the suggested ingredients for the style."
+     :json-schema/example   "water, barley, and hops."}))
 
 
 (spec/def ::examples
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting example beers of this style."
-     :json-schema/example "Every overly citrus IPA on the market."}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting example beers of this style."
+     :json-schema/example   "Every overly citrus IPA on the market."}))
 
 
 (spec/def ::display-og-min
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Original Gravity Min"
-     :description          "A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.036sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Original Gravity Min"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.036sg"}))
 
 
 (spec/def ::display-og-max
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Original Gravity Max"
-     :description          "A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Original Gravity Max"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-fg-min
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Final Gravity Min"
-     :description          "A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.036sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Final Gravity Min"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.036sg"}))
 
 
 (spec/def ::display-fg-max
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Final Gravity Max"
-     :description          "A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units."
-     :json-schema/example  "1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Display Final Gravity Max"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units."
+     :json-schema/example   "1.050sg"}))
 
 
 (spec/def ::display-color-min
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units."
-     :json-schema/example "32SRM"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units."
+     :json-schema/example   "32SRM"}))
 
 
 (spec/def ::display-color-max
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units."
-     :json-schema/example "40 SRM"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units."
+     :json-schema/example   "40 SRM"}))
 
 
 (spec/def ::og-range
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Original Gravity Range"
-     :description          "A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units."
-     :json-schema/example  "1.036sg-1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Original Gravity Range"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units."
+     :json-schema/example   "1.036sg-1.050sg"}))
 
 
 (spec/def ::fg-range
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Final Gravity Range"
-     :description          "A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units."
-     :json-schema/example  "1.036sg-1.050sg"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Final Gravity Range"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units."
+     :json-schema/example   "1.036sg-1.050sg"}))
 
 
 (spec/def ::ibu-range
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "International Bittering Units Range"
-     :description          "A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units."
-     :json-schema/example  "10-20IBUs"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "International Bittering Units Range"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units."
+     :json-schema/example   "10-20IBUs"}))
 
 
 (spec/def ::carb-range
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Carbonation Range"
-     :description          "A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units."
-     :json-schema/example  "2.0-2.6 vols CO2"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/display-name-key  "Carbonation Range"
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units."
+     :json-schema/example   "2.0-2.6 vols CO2"}))
 
 
 (spec/def ::color-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units."
-     :json-schema/example "10 - 22 SRM"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units."
+     :json-schema/example   "10 - 22 SRM"}))
 
 
 (spec/def ::abv-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units."
-     :json-schema/example "8.0-11.2%"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units."
+     :json-schema/example   "8.0-11.2%"}))
 
 
 (spec/def ::style
@@ -574,16 +618,17 @@
 
 (spec/def ::style-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::style` record wrapped in a `:style` map"
-     :spec                 (spec/keys :req-un [::style])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::style` record wrapped in a `:style` map."
+     :spec                  (spec/keys :req-un [::style])}))
 
 
 (spec/def ::styles
   (st/spec
     {:type          :vector
-     :description   "A vector of valid `::style` records"
+     :description   "A vector of valid `::style` records."
      :spec          (spec/coll-of ::style-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::style-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::style-wrapper %2)}))
@@ -591,7 +636,8 @@
 
 (spec/def ::styles-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::styles-wrapper` record"
-     :spec                 (spec/keys :req-un [::styles])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::styles-wrapper` record set."
+     :spec                  (spec/keys :req-un [::styles])}))

--- a/src/common_beer_format/styles.cljc
+++ b/src/common_beer_format/styles.cljc
@@ -2,7 +2,6 @@
   "The definition of a style record used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -50,10 +49,10 @@
 
 
 (def type
-  "A case-insensitive string representing the type of beverage the style dictates.
-   
+  "A case-sensitive string representing the type of beverage the style dictates.
+
    Currently, the following values are supported:
-   
+
    - \"Ale\" - A top-fermented beer with a fruity, hoppy taste and a dry finish.
    - \"Lager\" - A light, bottom-fermented beer with a clean, crisp taste and a smooth finish.
    - \"Mead\" - A fermented beverage made from honey and water.
@@ -207,7 +206,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the category this style belongs to"
+     :description         "A non-empty string denoting the category this style belongs to."
      :json-schema/example "American Lagers"}))
 
 
@@ -224,7 +223,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the letter used to denote the style or sub-style"
+     :description         "A non-empty string denoting the letter used to denote the style or sub-style."
      :json-schema/example "A"}))
 
 
@@ -232,38 +231,38 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the name of the style guide the style/category belongs to"
+     :description         "A non-empty string denoting the name of the style guide the style/category belongs to."
      :json-schema/example "BJCP"}))
 
 
 (def lager
   "A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
-  "lager")
+  "Lager")
 
 
 (def ale
   "A top-fermented beer with a fruity, hoppy taste and a dry finish."
-  "ale")
+  "Ale")
 
 
 (def mead
   "A fermented beverage made from honey and water."
-  "mead")
+  "Mead")
 
 
 (def wheat
   "A beer made with a large proportion of wheat malt."
-  "wheat")
+  "Wheat")
 
 
 (def mixed
   "A beer style that blends two or more styles."
-  "mixed")
+  "Mixed")
 
 
 (def cider
   "A fermented beverage made from fruit and water."
-  "cider")
+  "Cider")
 
 
 (def style-types
@@ -278,64 +277,76 @@
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? style-types (str/lower-case %)))
-     :gen                 #(spec/gen style-types)
-     :description         (impl/multiline "A case-insensitive string representing the type of beverage the style dictates."
-                                          (impl/set->description style-types))
-     :json-schema/example "Lager"}))
+   {:type                :string
+    :spec                style-types
+    :gen                 #(spec/gen style-types)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the type of beverage the style dictates."
+                          (impl/set->description style-types)
+                          ""
+                          "- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish."
+                          "- Cider: A fermented beverage made from fruit and water."
+                          "- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
+                          "- Mead: A fermented beverage made from honey and water."
+                          "- Mixed: A beer style that blends two or more styles."
+                          "- Wheat: A beer made with a large proportion of wheat malt.")
+    :json-schema/example "Lager"}))
 
 
 (spec/def ::og-min
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style"
-     :json-schema/example "1.048"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Minimum Original Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the minimum pre-fermentation specific gravity for the style."
+     :json-schema/example  "1.048"}))
 
 
 (spec/def ::og-max
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style"
-     :json-schema/example "1.060"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Maximum Original Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the maximum pre-fermentation specific gravity for the style."
+     :json-schema/example  "1.060"}))
 
 
 (spec/def ::fg-min
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style"
-     :json-schema/example "1.048"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Minimum Final Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the minimum post-fermentation specific gravity for the style."
+     :json-schema/example  "1.048"}))
 
 
 (spec/def ::fg-max
   (st/spec
-    {:type                :double
-     :spec                ::prim/specific-gravity
-     :description         "A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style"
-     :json-schema/example "1.060"}))
+    {:type                 :double
+     :spec                 ::prim/specific-gravity
+     impl/display-name-key "Maximum Final Gravity"
+     :description          "A non-negative IEEE-754 floating point number representing the maximum post-fermentation specific gravity for the style."
+     :json-schema/example  "1.060"}))
 
 
 (spec/def ::ibu-min
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style"
-     :json-schema/example "32"}))
+    {:type                 :double
+     :spec                 number?
+     impl/display-name-key "Minimum International Bittering Units"
+     :gen                  impl/real-double-generator
+     :description          "A non-negative IEEE-754 floating point number representing the minimum bitterness in IBUs for the style."
+     :json-schema/example  "32"}))
 
 
 (spec/def ::ibu-max
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style"
-     :json-schema/example "40"}))
+    {:type                 :double
+     :spec                 number?
+     impl/display-name-key "Maximum International Bittering Units"
+     :gen                  impl/real-double-generator
+     :description          "A non-negative IEEE-754 floating point number representing the maximum bitterness in IBUs for the style."
+     :json-schema/example  "40"}))
 
 
 (spec/def ::color-min
@@ -343,7 +354,7 @@
     {:type                :double
      :spec                number?
      :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style"
+     :description         "A non-negative IEEE-754 floating point number representing the lightest color in SRM for the style."
      :json-schema/example "32"}))
 
 
@@ -352,33 +363,35 @@
     {:type                :double
      :spec                number?
      :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style"
+     :description         "A non-negative IEEE-754 floating point number representing the darkest color in SRM for the style."
      :json-schema/example "40"}))
 
 
 (spec/def ::carb-min
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2"
-     :json-schema/example "1.5"}))
+    {:type                 :double
+     :spec                 number?
+     impl/display-name-key "Minimum Carbonation"
+     :gen                  impl/real-double-generator
+     :description          "A non-negative IEEE-754 floating point number representing the minimum carbonation for this style in volumes of CO2."
+     :json-schema/example  "1.5"}))
 
 
 (spec/def ::carb-max
   (st/spec
-    {:type                :double
-     :spec                number?
-     :gen                 impl/real-double-generator
-     :description         "A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2"
-     :json-schema/example "2.2"}))
+    {:type                 :double
+     :spec                 number?
+     impl/display-name-key "Maximum Carbonation"
+     :gen                  impl/real-double-generator
+     :description          "A non-negative IEEE-754 floating point number representing the maximum carbonation for this style in volumes of CO2."
+     :json-schema/example  "2.2"}))
 
 
 (spec/def ::abv-min
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style"
+     :description         "A non-negative IEEE-754 floating point number representing the minimum recommended ABV percentage for the style."
      :json-schema/example "0.032"}))
 
 
@@ -386,7 +399,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style"
+     :description         "A non-negative IEEE-754 floating point number representing the maximum recommended ABV percentage for the style."
      :json-schema/example "0.04"}))
 
 
@@ -394,63 +407,67 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the aroma and flavor profile of the style"
-     :json-schema/example "Full-bodied and dark"}))
+     :description         "A non-empty string denoting the aroma and flavor profile of the style."
+     :json-schema/example "Full-bodied and dark."}))
 
 
 (spec/def ::ingredients
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the suggested ingredients for the style"
-     :json-schema/example "water, barley, and hops"}))
+     :description         "A non-empty string denoting the suggested ingredients for the style."
+     :json-schema/example "water, barley, and hops."}))
 
 
 (spec/def ::examples
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting example beers of this style"
-     :json-schema/example "Every overly citrus IPA on the market"}))
+     :description         "A non-empty string denoting example beers of this style."
+     :json-schema/example "Every overly citrus IPA on the market."}))
 
 
 (spec/def ::display-og-min
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units"
-     :json-schema/example "1.036sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Original Gravity Min"
+     :description          "A non-empty string denoting a display value for the minimum original gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.036sg"}))
 
 
 (spec/def ::display-og-max
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units"
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Original Gravity Max"
+     :description          "A non-empty string denoting a display value for the maximum original gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::display-fg-min
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units"
-     :json-schema/example "1.036sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Final Gravity Min"
+     :description          "A non-empty string denoting a display value for the minimum final gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.036sg"}))
 
 
 (spec/def ::display-fg-max
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units"
-     :json-schema/example "1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Final Gravity Max"
+     :description          "A non-empty string denoting a display value for the maximum final gravity formatted for display in arbitrary units."
+     :json-schema/example  "1.050sg"}))
 
 
 (spec/def ::display-color-min
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the minimum color formatted for display in arbitrary units."
      :json-schema/example "32SRM"}))
 
 
@@ -458,47 +475,51 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the maximum color formatted for display in arbitrary units."
      :json-schema/example "40 SRM"}))
 
 
 (spec/def ::og-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units"
-     :json-schema/example "1.036sg-1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Original Gravity Range"
+     :description          "A non-empty string denoting a display value for the range of original gravities formatted for display in arbitrary units."
+     :json-schema/example  "1.036sg-1.050sg"}))
 
 
 (spec/def ::fg-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units"
-     :json-schema/example "1.036sg-1.050sg"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Final Gravity Range"
+     :description          "A non-empty string denoting a display value for the range of final gravities formatted for display in arbitrary units."
+     :json-schema/example  "1.036sg-1.050sg"}))
 
 
 (spec/def ::ibu-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units"
-     :json-schema/example "10-20IBUs"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "International Bittering Units Range"
+     :description          "A non-empty string denoting a display value for the range of International Bittering Units formatted for display in arbitrary units."
+     :json-schema/example  "10-20IBUs"}))
 
 
 (spec/def ::carb-range
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units"
-     :json-schema/example "2.0-2.6 vols CO2"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Carbonation Range"
+     :description          "A non-empty string denoting a display value for the range of carbonation volumes formatted for display in arbitrary units."
+     :json-schema/example  "2.0-2.6 vols CO2"}))
 
 
 (spec/def ::color-range
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the range of colors formatted for display in arbitrary units."
      :json-schema/example "10 - 22 SRM"}))
 
 
@@ -506,7 +527,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units"
+     :description         "A non-empty string denoting a display value for the range of ABV levels formatted for display in arbitrary units."
      :json-schema/example "8.0-11.2%"}))
 
 
@@ -553,15 +574,16 @@
 
 (spec/def ::style-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::style record wrapped in a ::style map"
-     :spec        (spec/keys :req-un [::style])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::style` record wrapped in a `:style` map"
+     :spec                 (spec/keys :req-un [::style])}))
 
 
 (spec/def ::styles
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::style records"
+     :description   "A vector of valid `::style` records"
      :spec          (spec/coll-of ::style-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::style-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::style-wrapper %2)}))
@@ -569,6 +591,7 @@
 
 (spec/def ::styles-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::styles-wrapper record"
-     :spec        (spec/keys :req-un [::styles])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::styles-wrapper` record"
+     :spec                 (spec/keys :req-un [::styles])}))

--- a/src/common_beer_format/styles.cljc
+++ b/src/common_beer_format/styles.cljc
@@ -281,21 +281,21 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  style-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen style-types)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the type of beverage the style dictates."
-                            (impl/set->description style-types)
-                            ""
-                            "- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish."
-                            "- Cider: A fermented beverage made from fruit and water."
-                            "- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
-                            "- Mead: A fermented beverage made from honey and water."
-                            "- Mixed: A beer style that blends two or more styles."
-                            "- Wheat: A beer made with a large proportion of wheat malt.")
-    :json-schema/example   "Lager"}))
+    {:type                  :string
+     :spec                  style-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen style-types)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the type of beverage the style dictates."
+                              (impl/set->description style-types)
+                              ""
+                              "- Ale: A top-fermented beer with a fruity, hoppy taste and a dry finish."
+                              "- Cider: A fermented beverage made from fruit and water."
+                              "- Lager: A light, bottom-fermented beer with a clean, crisp taste and a smooth finish."
+                              "- Mead: A fermented beverage made from honey and water."
+                              "- Mixed: A beer style that blends two or more styles."
+                              "- Wheat: A beer made with a large proportion of wheat malt.")
+     :json-schema/example   "Lager"}))
 
 
 (spec/def ::og-min

--- a/src/common_beer_format/waters.cljc
+++ b/src/common_beer_format/waters.cljc
@@ -83,7 +83,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million."
      :json-schema/example "2.5"}))
 
 
@@ -92,7 +92,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million."
      :json-schema/example "2.5"}))
 
 
@@ -101,7 +101,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million."
      :json-schema/example "2.5"}))
 
 
@@ -110,7 +110,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million."
      :json-schema/example "2.5"}))
 
 
@@ -119,7 +119,7 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million."
      :json-schema/example "2.5"}))
 
 
@@ -128,17 +128,18 @@
     {:type                :double
      :spec                (spec/and number? pos?)
      :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million"
+     :description         "A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million."
      :json-schema/example "2.5"}))
 
 
 (spec/def ::ph
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the PH of the water"
-     :json-schema/example "2.5"}))
+    {:type                 :double
+     :spec                 (spec/and number? pos?)
+     impl/display-name-key "PH"
+     :gen                  impl/real-positive-double-generator
+     :description          "A positive IEEE-754 floating point number representing the PH of the water."
+     :json-schema/example  "2.5"}))
 
 
 (spec/def ::water
@@ -161,15 +162,16 @@
 
 (spec/def ::water-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::water record wrapped in a ::water map."
-     :spec        (spec/keys :req-un [::water])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::water` record wrapped in a `:water` map."
+     :spec                 (spec/keys :req-un [::water])}))
 
 
 (spec/def ::waters
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::water records."
+     :description   "A vector of valid `::water` records."
      :spec          (spec/coll-of ::water-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::water-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::water-wrapper %2)}))
@@ -177,6 +179,7 @@
 
 (spec/def ::waters-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::waterss-wrapper record."
-     :spec        (spec/keys :req-un [::waters])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::waters-wrapper` record."
+     :spec                 (spec/keys :req-un [::waters])}))

--- a/src/common_beer_format/waters.cljc
+++ b/src/common_beer_format/waters.cljc
@@ -80,66 +80,73 @@
 
 (spec/def ::calcium
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of calcium (Ca) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::bicarbonate
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of bicarbonate (HCO3) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::sulfate
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of sulfate (SO4) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::chloride
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of chloride (Cl-) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::sodium
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of sodium (Na) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::magnesium
   (st/spec
-    {:type                :double
-     :spec                (spec/and number? pos?)
-     :gen                 impl/real-positive-double-generator
-     :description         "A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million."
-     :json-schema/example "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the amount of magnesium (Mg) in parts per million."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::ph
   (st/spec
-    {:type                 :double
-     :spec                 (spec/and number? pos?)
-     impl/display-name-key "PH"
-     :gen                  impl/real-positive-double-generator
-     :description          "A positive IEEE-754 floating point number representing the PH of the water."
-     :json-schema/example  "2.5"}))
+    {:type                  :double
+     :spec                  ::prim/non-negative-number
+     impl/display-name-key  "PH"
+     impl/beer-xml-type-key impl/beer-xml-floating-point
+     :gen                   impl/real-positive-double-generator
+     :description           "A positive IEEE-754 floating point number representing the PH of the water."
+     :json-schema/example   "2.5"}))
 
 
 (spec/def ::water
@@ -162,10 +169,11 @@
 
 (spec/def ::water-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::water` record wrapped in a `:water` map."
-     :spec                 (spec/keys :req-un [::water])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::water` record wrapped in a `:water` map."
+     :spec                  (spec/keys :req-un [::water])}))
 
 
 (spec/def ::waters
@@ -179,7 +187,8 @@
 
 (spec/def ::waters-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::waters-wrapper` record."
-     :spec                 (spec/keys :req-un [::waters])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::waters-wrapper` record set."
+     :spec                  (spec/keys :req-un [::waters])}))

--- a/src/common_beer_format/yeasts.cljc
+++ b/src/common_beer_format/yeasts.cljc
@@ -2,7 +2,6 @@
   "The definition of a yeast record used in BeerXML."
   {:added "2.0"}
   (:require [clojure.spec.alpha :as spec]
-            [clojure.string :as str]
             [common-beer-format.impl :as impl]
             [common-beer-format.primitives :as prim]
             [spec-tools.core :as st])
@@ -37,9 +36,9 @@
 
 (def type
   "The type of yeast, usually categorized by the intended beverage or style.
-   
+
    Currently, the following types are supported:
-   
+
    - `ale` - Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer.
    - `lager` - Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer.
    - `wheat` - Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer.
@@ -50,27 +49,27 @@
 
 (def ale
   "Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
-  "ale")
+  "Ale")
 
 
 (def lager
   "Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
-  "lager")
+  "Lager")
 
 
 (def wheat
   "Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
-  "wheat")
+  "Wheat")
 
 
 (def wine
   "Yeast traditionally used in wine making."
-  "wine")
+  "Wine")
 
 
 (def champagne
   "Yeast traditionally used in champagne making, offering a dry taste."
-  "champagne")
+  "Champagne")
 
 
 (def yeast-types
@@ -84,46 +83,51 @@
 
 (def form
   "The form of the yeast added to the beer.
-   
+
    Currently, the following forms are supported:
-   
-   - `liquid` - A liquid slurry of yeast, usually with a source of nutrietns or sugars.
+
+   - `liquid` - A liquid slurry of yeast, usually with a source of nutrients or sugars.
    - `dry` - Dry yeast sold in a dehydrated state to extend shelf life.
    - `slant` - Yeast cultivated on a solid growth medium.
-   - `culture` - Yeast clutivated from previous fermentations."
+   - `culture` - Yeast cultivated from previous fermentations."
   :form)
 
 
 (def liquid
-  "A liquid slurry of yeast, usually with a source of nutrietns or sugars."
-  "liquid")
+  "A liquid slurry of yeast, usually with a source of nutrients or sugars."
+  "Liquid")
 
 
 (def dry
   "Dry yeast sold in a dehydrated state to extend shelf life."
-  "dry")
+  "Dry")
 
 
 (def slant
   "Yeast cultivated on a solid growth medium."
-  "slant")
+  "Slant")
 
 
 (def culture
-  "Yeast clutivated from previous fermentations."
-  "culture")
+  "Yeast cultivated from previous fermentations."
+  "Culture")
 
 
 (spec/def ::type
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? yeast-types (str/lower-case %)))
-     :gen                 #(spec/gen yeast-types)
-     :description         (impl/multiline "A case-insensitive string representing the type of yeast added to the beer."
-                                          (impl/set->description yeast-types))
-     :json-schema/example "Ale"}))
+   {:type                :string
+    :spec                yeast-types
+    :gen                 #(spec/gen yeast-types)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the type of yeast added to the beer."
+                          (impl/set->description yeast-types)
+                          ""
+                          "- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
+                          "- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
+                          "- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
+                          "- Wine: Yeast traditionally used in wine making."
+                          "- Champagne: Yeast traditionally used in champagne making, offering a dry taste.")
+    :json-schema/example "Ale"}))
 
 
 (def yeast-forms
@@ -150,20 +154,20 @@
 
 
 (def min-temperature
-  "The minimum recommended temperature of fermenation."
+  "The minimum recommended temperature of fermentation."
   :min-temperature)
 
 
 (def max-temperature
-  "The maximum recommended temperature of fermenation."
+  "The maximum recommended temperature of fermentation."
   :max-temperature)
 
 
 (def flocculation
   "The rate at which the yeast settles out of suspension.
-   
+
    Currently, the following flocculation types are supported:
-   
+
    - `low` - The yeast settles out of suspension slowly.
    - `medium` - The yeast settles out of suspension at a moderate rate.
    - `high` - The yeast settles out of suspension quickly.
@@ -173,22 +177,22 @@
 
 (def low
   "The yeast settles out of suspension slowly."
-  "low")
+  "Low")
 
 
 (def medium
   "The yeast settles out of suspension at a moderate rate."
-  "medium")
+  "Medium")
 
 
 (def high
   "The yeast settles out of suspension quickly."
-  "high")
+  "High")
 
 
 (def very-high
   "The yeast settles out of suspension very quickly."
-  "very high")
+  "Very High")
 
 
 (def attenuation
@@ -227,12 +231,12 @@
 
 
 (def disp-min-temp
-  "A human-readable string representing the minimum recommended temperature of fermenation."
+  "A human-readable string representing the minimum recommended temperature of fermentation."
   :disp-min-temp)
 
 
 (def disp-max-temp
-  "A human-readable string representing the maximum recommended temperature of fermenation."
+  "A human-readable string representing the maximum recommended temperature of fermentation."
   :disp-max-temp)
 
 
@@ -248,21 +252,25 @@
 
 (spec/def ::form
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? yeast-forms (str/lower-case %)))
-     :gen                 #(spec/gen yeast-forms)
-     :description         (impl/multiline "A case-insensitive string representing the form of the yeast added to the beer."
-                                          (impl/set->description yeast-forms))
-     :json-schema/example "Ale"}))
+   {:type                :string
+    :spec                yeast-forms
+    :gen                 #(spec/gen yeast-forms)
+    :description         (impl/multiline
+                          "A case-sensitive string representing the form of the yeast added to the beer."
+                          (impl/set->description yeast-forms)
+                          ""
+                          "- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars."
+                          "- Dry: Dry yeast sold in a dehydrated state to extend shelf life."
+                          "- Slant: Yeast cultivated on a solid growth medium."
+                          "- Culture: Yeast cultivated from previous fermentations.")
+    :json-schema/example "Ale"}))
 
 
 (spec/def ::laboratory
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the laboratory that cultivated the yeast"
+     :description         "A non-empty string denoting the laboratory that cultivated the yeast."
      :json-schema/example "White Labs"}))
 
 
@@ -270,7 +278,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the product label or id number that identifies the strain of yeast"
+     :description         "A non-empty string denoting the product label or id number that identifies the strain of yeast."
      :json-schema/example "WLP008"}))
 
 
@@ -278,7 +286,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the minimum recommended temperature of fermenation"
+     :description         "An IEEE-754 floating point number representing the minimum recommended temperature of fermentation."
      :json-schema/example "19.5"}))
 
 
@@ -286,7 +294,7 @@
   (st/spec
     {:type                :double
      :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the maximum recommended temperature of fermenation"
+     :description         "An IEEE-754 floating point number representing the maximum recommended temperature of fermentation."
      :json-schema/example "23.9"}))
 
 
@@ -300,21 +308,24 @@
 
 (spec/def ::flocculation
   (st/spec
-    {:type                :string
-     :spec                (spec/and string?
-                                    #(not (str/blank? %))
-                                    #(contains? yeast-flocculation-types (str/lower-case %)))
-     :gen                 #(spec/gen yeast-flocculation-types)
-     :description         (impl/multiline "A case-insensitive string representing how dense of a floc the yeast will form."
-                                          (impl/set->description yeast-flocculation-types))
-     :json-schema/example "High"}))
+   {:type                :string
+    :spec                yeast-flocculation-types
+    :gen                 #(spec/gen yeast-flocculation-types)
+    :description         (impl/multiline "A case-sensitive string representing how dense of a floc the yeast will form."
+                                         (impl/set->description yeast-flocculation-types)
+                                         ""
+                                         "- Low: The yeast settles out of suspension slowly."
+                                         "- Medium: The yeast settles out of suspension at a moderate rate."
+                                         "- High: The yeast settles out of suspension quickly."
+                                         "- Very High: The yeast settles out of suspension very quickly.")
+    :json-schema/example "High"}))
 
 
 (spec/def ::attenuation
   (st/spec
     {:type                :double
      :spec                ::prim/percent
-     :description         "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide"
+     :description         "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide."
      :json-schema/example "73.2"}))
 
 
@@ -322,7 +333,7 @@
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting the styles of beer this yeast is best suited for"
+     :description         "A non-empty string denoting the styles of beer this yeast is best suited for."
      :json-schema/example "WLP008"}))
 
 
@@ -340,7 +351,7 @@
   (st/spec
     {:type                :long
      :spec                (spec/and int? #(not (neg? %)))
-     :description         "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured"
+     :description         "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured."
      :json-schema/example "3"}))
 
 
@@ -357,25 +368,27 @@
 
 (spec/def ::disp-min-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units"
-     :json-schema/example "68F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Minimum Temperature"
+     :description          "A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units."
+     :json-schema/example  "68F"}))
 
 
 (spec/def ::disp-max-temp
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units"
-     :json-schema/example "75F"}))
+    {:type                 :string
+     :spec                 ::prim/text
+     impl/display-name-key "Display Maximum Temperature"
+     :description          "A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units."
+     :json-schema/example  "75F"}))
 
 
 (spec/def ::culture-date
   (st/spec
     {:type                :string
      :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure"
+     :description         "A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure."
      :json-schema/example "10/10/2020"}))
 
 
@@ -409,15 +422,16 @@
 
 (spec/def ::yeast-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::yeast record wrapped in a ::yeast map."
-     :spec        (spec/keys :req-un [::yeast])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::yeast` record wrapped in a `:yeast` map."
+     :spec                 (spec/keys :req-un [::yeast])}))
 
 
 (spec/def ::yeasts
   (st/spec
     {:type          :vector
-     :description   "A vector of valid ::yeast records."
+     :description   "A vector of valid `::yeast` records."
      :spec          (spec/coll-of ::yeast-wrapper :into [] :kind vector?)
      :decode/string #(impl/decode-sequence %1 ::yeast-wrapper %2)
      :encode/string #(impl/encode-sequence %1 ::yeast-wrapper %2)}))
@@ -425,6 +439,7 @@
 
 (spec/def ::yeasts-wrapper
   (st/spec
-    {:type        :map
-     :description "A ::yeasts-wrapper record."
-     :spec        (spec/keys :req-un [::yeasts])}))
+    {:type                 :map
+     impl/wrapper-spec-key true
+     :description          "A `::yeasts-wrapper` record."
+     :spec                 (spec/keys :req-un [::yeasts])}))

--- a/src/common_beer_format/yeasts.cljc
+++ b/src/common_beer_format/yeasts.cljc
@@ -115,19 +115,20 @@
 
 (spec/def ::type
   (st/spec
-   {:type                :string
-    :spec                yeast-types
-    :gen                 #(spec/gen yeast-types)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the type of yeast added to the beer."
-                          (impl/set->description yeast-types)
-                          ""
-                          "- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
-                          "- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
-                          "- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
-                          "- Wine: Yeast traditionally used in wine making."
-                          "- Champagne: Yeast traditionally used in champagne making, offering a dry taste.")
-    :json-schema/example "Ale"}))
+   {:type                  :string
+    :spec                  yeast-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen yeast-types)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the type of yeast added to the beer."
+                            (impl/set->description yeast-types)
+                            ""
+                            "- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
+                            "- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
+                            "- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
+                            "- Wine: Yeast traditionally used in wine making."
+                            "- Champagne: Yeast traditionally used in champagne making, offering a dry taste.")
+    :json-schema/example   "Ale"}))
 
 
 (def yeast-forms
@@ -252,50 +253,59 @@
 
 (spec/def ::form
   (st/spec
-   {:type                :string
-    :spec                yeast-forms
-    :gen                 #(spec/gen yeast-forms)
-    :description         (impl/multiline
-                          "A case-sensitive string representing the form of the yeast added to the beer."
-                          (impl/set->description yeast-forms)
-                          ""
-                          "- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars."
-                          "- Dry: Dry yeast sold in a dehydrated state to extend shelf life."
-                          "- Slant: Yeast cultivated on a solid growth medium."
-                          "- Culture: Yeast cultivated from previous fermentations.")
-    :json-schema/example "Ale"}))
+   {:type                  :string
+    :spec                  yeast-forms
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen yeast-forms)
+    :description           (impl/multiline
+                            "A case-sensitive string representing the form of the yeast added to the beer."
+                            (impl/set->description yeast-forms)
+                            ""
+                            "- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars."
+                            "- Dry: Dry yeast sold in a dehydrated state to extend shelf life."
+                            "- Slant: Yeast cultivated on a solid growth medium."
+                            "- Culture: Yeast cultivated from previous fermentations.")
+    :json-schema/example   "Ale"}))
 
 
 (spec/def ::laboratory
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the laboratory that cultivated the yeast."
-     :json-schema/example "White Labs"}))
+   {:type                  :string
+    :spec                  ::prim/text
+    impl/beer-xml-type-key impl/beer-xml-text
+    :description           "A non-empty string denoting the laboratory that cultivated the yeast."
+    :json-schema/example   "White Labs"}))
 
 
 (spec/def ::product-id
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the product label or id number that identifies the strain of yeast."
-     :json-schema/example "WLP008"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the product label or id number that identifies the strain of yeast."
+     :json-schema/example   "WLP008"}))
 
 
 (spec/def ::min-temperature
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the minimum recommended temperature of fermentation."
-     :json-schema/example "19.5"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/display-name-key   "Minimum Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :description            "An IEEE-754 floating point number representing the minimum recommended temperature of fermentation."
+     :json-schema/example    "19.5"}))
 
 
 (spec/def ::max-temperature
   (st/spec
-    {:type                :double
-     :spec                ::prim/degrees-celsius
-     :description         "An IEEE-754 floating point number representing the maximum recommended temperature of fermentation."
-     :json-schema/example "23.9"}))
+    {:type                   :double
+     :spec                   ::prim/degrees-celsius
+     impl/display-name-key   "Maximum Temperature"
+     impl/beer-xml-type-key  impl/beer-xml-floating-point
+     impl/beer-xml-units-key impl/beer-xml-degrees-celsius
+     :description            "An IEEE-754 floating point number representing the maximum recommended temperature of fermentation."
+     :json-schema/example    "23.9"}))
 
 
 (def yeast-flocculation-types
@@ -308,88 +318,97 @@
 
 (spec/def ::flocculation
   (st/spec
-   {:type                :string
-    :spec                yeast-flocculation-types
-    :gen                 #(spec/gen yeast-flocculation-types)
-    :description         (impl/multiline "A case-sensitive string representing how dense of a floc the yeast will form."
-                                         (impl/set->description yeast-flocculation-types)
-                                         ""
-                                         "- Low: The yeast settles out of suspension slowly."
-                                         "- Medium: The yeast settles out of suspension at a moderate rate."
-                                         "- High: The yeast settles out of suspension quickly."
-                                         "- Very High: The yeast settles out of suspension very quickly.")
-    :json-schema/example "High"}))
+   {:type                  :string
+    :spec                  yeast-flocculation-types
+    impl/beer-xml-type-key impl/beer-xml-list
+    :gen                   #(spec/gen yeast-flocculation-types)
+    :description           (impl/multiline "A case-sensitive string representing how dense of a floc the yeast will form."
+                                           (impl/set->description yeast-flocculation-types)
+                                           ""
+                                           "- Low: The yeast settles out of suspension slowly."
+                                           "- Medium: The yeast settles out of suspension at a moderate rate."
+                                           "- High: The yeast settles out of suspension quickly."
+                                           "- Very High: The yeast settles out of suspension very quickly.")
+    :json-schema/example   "High"}))
 
 
 (spec/def ::attenuation
   (st/spec
-    {:type                :double
-     :spec                ::prim/percent
-     :description         "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide."
-     :json-schema/example "73.2"}))
+   {:type                  :double
+    :spec                  ::prim/percent
+    impl/beer-xml-type-key impl/beer-xml-percentage
+    :description           "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide."
+    :json-schema/example   "73.2"}))
 
 
 (spec/def ::best-for
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting the styles of beer this yeast is best suited for."
-     :json-schema/example "WLP008"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the styles of beer this yeast is best suited for."
+     :json-schema/example   "WLP008"}))
 
 
 (spec/def ::times-cultured
   (st/spec
-    {:type                :long
-     :spec                (spec/and int? #(not (neg? %)))
-     :description         (impl/multiline
+   {:type                  :long
+    :spec                  (spec/and int? pos?)
+    impl/beer-xml-type-key impl/beer-xml-integer
+    :description           (impl/multiline
                             "A non-negative integer representing the number of times this yeast has been harvested and re-used."
                             "A value of zero assumes the yeast came directly from the manufacturer.")
-     :json-schema/example "1"}))
+    :json-schema/example   "1"}))
 
 
 (spec/def ::max-reuse
   (st/spec
-    {:type                :long
-     :spec                (spec/and int? #(not (neg? %)))
-     :description         "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured."
-     :json-schema/example "3"}))
+   {:type                  :long
+    :spec                  (spec/and int? pos?)
+    impl/beer-xml-type-key impl/beer-xml-integer
+    :description           "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured."
+    :json-schema/example   "3"}))
 
 
 (spec/def ::add-to-secondary
   (st/spec
-    {:spec                ::prim/boolean
-     :description         (impl/multiline
+   {:spec                  ::prim/boolean
+    impl/beer-xml-type-key impl/beer-xml-boolean
+    :description           (impl/multiline
                             "A boolean representing if this yeast was added for a secondary fermentation."
                             "When absent, assume false.")
-     :json-schema/example "false"
-     :decode/string       impl/decode-boolean
-     :encode/string       impl/encode-boolean}))
+    :json-schema/example   "false"
+    :decode/string         impl/decode-boolean
+    :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::disp-min-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Minimum Temperature"
-     :description          "A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units."
-     :json-schema/example  "68F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     impl/display-name-key  "Display Minimum Temperature"
+     :description           "A non-empty string denoting a display value for the minimum fermentation temperature formatted for display in arbitrary units."
+     :json-schema/example   "68F"}))
 
 
 (spec/def ::disp-max-temp
   (st/spec
-    {:type                 :string
-     :spec                 ::prim/text
-     impl/display-name-key "Display Maximum Temperature"
-     :description          "A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units."
-     :json-schema/example  "75F"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     impl/display-name-key  "Display Maximum Temperature"
+     :description           "A non-empty string denoting a display value for the maximum fermentation temperature formatted for display in arbitrary units."
+     :json-schema/example   "75F"}))
 
 
 (spec/def ::culture-date
   (st/spec
-    {:type                :string
-     :spec                ::prim/text
-     :description         "A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure."
-     :json-schema/example "10/10/2020"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting a display value for the date the yeast sample was last cultured formatted for display in arbitrary structure."
+     :json-schema/example   "10/10/2020"}))
 
 
 (spec/def ::yeast
@@ -422,10 +441,11 @@
 
 (spec/def ::yeast-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::yeast` record wrapped in a `:yeast` map."
-     :spec                 (spec/keys :req-un [::yeast])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record
+     :description           "A `::yeast` record wrapped in a `:yeast` map."
+     :spec                  (spec/keys :req-un [::yeast])}))
 
 
 (spec/def ::yeasts
@@ -439,7 +459,8 @@
 
 (spec/def ::yeasts-wrapper
   (st/spec
-    {:type                 :map
-     impl/wrapper-spec-key true
-     :description          "A `::yeasts-wrapper` record."
-     :spec                 (spec/keys :req-un [::yeasts])}))
+    {:type                  :map
+     impl/wrapper-spec-key  true
+     impl/beer-xml-type-key impl/beer-xml-record-set
+     :description           "A `::yeasts-wrapper` record set."
+     :spec                  (spec/keys :req-un [::yeasts])}))

--- a/src/common_beer_format/yeasts.cljc
+++ b/src/common_beer_format/yeasts.cljc
@@ -115,20 +115,20 @@
 
 (spec/def ::type
   (st/spec
-   {:type                  :string
-    :spec                  yeast-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen yeast-types)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the type of yeast added to the beer."
-                            (impl/set->description yeast-types)
-                            ""
-                            "- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
-                            "- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
-                            "- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
-                            "- Wine: Yeast traditionally used in wine making."
-                            "- Champagne: Yeast traditionally used in champagne making, offering a dry taste.")
-    :json-schema/example   "Ale"}))
+    {:type                  :string
+     :spec                  yeast-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen yeast-types)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the type of yeast added to the beer."
+                              (impl/set->description yeast-types)
+                              ""
+                              "- Ale: Yeast that ferments at higher temperatures and produces a more fruity, estery, and alcohol-forward beer."
+                              "- Lager: Yeast that ferments at lower temperatures and produces a crisp, clean, and alcohol-restrained beer."
+                              "- Wheat: Yeast that ferments at higher temperatures and produces a fruity and phenol-forward beer."
+                              "- Wine: Yeast traditionally used in wine making."
+                              "- Champagne: Yeast traditionally used in champagne making, offering a dry taste.")
+     :json-schema/example   "Ale"}))
 
 
 (def yeast-forms
@@ -253,28 +253,28 @@
 
 (spec/def ::form
   (st/spec
-   {:type                  :string
-    :spec                  yeast-forms
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen yeast-forms)
-    :description           (impl/multiline
-                            "A case-sensitive string representing the form of the yeast added to the beer."
-                            (impl/set->description yeast-forms)
-                            ""
-                            "- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars."
-                            "- Dry: Dry yeast sold in a dehydrated state to extend shelf life."
-                            "- Slant: Yeast cultivated on a solid growth medium."
-                            "- Culture: Yeast cultivated from previous fermentations.")
-    :json-schema/example   "Ale"}))
+    {:type                  :string
+     :spec                  yeast-forms
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen yeast-forms)
+     :description           (impl/multiline
+                              "A case-sensitive string representing the form of the yeast added to the beer."
+                              (impl/set->description yeast-forms)
+                              ""
+                              "- Liquid: A liquid slurry of yeast, usually with a source of nutrients or sugars."
+                              "- Dry: Dry yeast sold in a dehydrated state to extend shelf life."
+                              "- Slant: Yeast cultivated on a solid growth medium."
+                              "- Culture: Yeast cultivated from previous fermentations.")
+     :json-schema/example   "Ale"}))
 
 
 (spec/def ::laboratory
   (st/spec
-   {:type                  :string
-    :spec                  ::prim/text
-    impl/beer-xml-type-key impl/beer-xml-text
-    :description           "A non-empty string denoting the laboratory that cultivated the yeast."
-    :json-schema/example   "White Labs"}))
+    {:type                  :string
+     :spec                  ::prim/text
+     impl/beer-xml-type-key impl/beer-xml-text
+     :description           "A non-empty string denoting the laboratory that cultivated the yeast."
+     :json-schema/example   "White Labs"}))
 
 
 (spec/def ::product-id
@@ -318,27 +318,27 @@
 
 (spec/def ::flocculation
   (st/spec
-   {:type                  :string
-    :spec                  yeast-flocculation-types
-    impl/beer-xml-type-key impl/beer-xml-list
-    :gen                   #(spec/gen yeast-flocculation-types)
-    :description           (impl/multiline "A case-sensitive string representing how dense of a floc the yeast will form."
-                                           (impl/set->description yeast-flocculation-types)
-                                           ""
-                                           "- Low: The yeast settles out of suspension slowly."
-                                           "- Medium: The yeast settles out of suspension at a moderate rate."
-                                           "- High: The yeast settles out of suspension quickly."
-                                           "- Very High: The yeast settles out of suspension very quickly.")
-    :json-schema/example   "High"}))
+    {:type                  :string
+     :spec                  yeast-flocculation-types
+     impl/beer-xml-type-key impl/beer-xml-list
+     :gen                   #(spec/gen yeast-flocculation-types)
+     :description           (impl/multiline "A case-sensitive string representing how dense of a floc the yeast will form."
+                                            (impl/set->description yeast-flocculation-types)
+                                            ""
+                                            "- Low: The yeast settles out of suspension slowly."
+                                            "- Medium: The yeast settles out of suspension at a moderate rate."
+                                            "- High: The yeast settles out of suspension quickly."
+                                            "- Very High: The yeast settles out of suspension very quickly.")
+     :json-schema/example   "High"}))
 
 
 (spec/def ::attenuation
   (st/spec
-   {:type                  :double
-    :spec                  ::prim/percent
-    impl/beer-xml-type-key impl/beer-xml-percentage
-    :description           "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide."
-    :json-schema/example   "73.2"}))
+    {:type                  :double
+     :spec                  ::prim/percent
+     impl/beer-xml-type-key impl/beer-xml-percentage
+     :description           "A positive IEEE-754 floating point number representing the percent of malt sugar that can be converted to ethanol and carbon dioxide."
+     :json-schema/example   "73.2"}))
 
 
 (spec/def ::best-for
@@ -352,34 +352,34 @@
 
 (spec/def ::times-cultured
   (st/spec
-   {:type                  :long
-    :spec                  (spec/and int? pos?)
-    impl/beer-xml-type-key impl/beer-xml-integer
-    :description           (impl/multiline
-                            "A non-negative integer representing the number of times this yeast has been harvested and re-used."
-                            "A value of zero assumes the yeast came directly from the manufacturer.")
-    :json-schema/example   "1"}))
+    {:type                  :long
+     :spec                  (spec/and int? pos?)
+     impl/beer-xml-type-key impl/beer-xml-integer
+     :description           (impl/multiline
+                              "A non-negative integer representing the number of times this yeast has been harvested and re-used."
+                              "A value of zero assumes the yeast came directly from the manufacturer.")
+     :json-schema/example   "1"}))
 
 
 (spec/def ::max-reuse
   (st/spec
-   {:type                  :long
-    :spec                  (spec/and int? pos?)
-    impl/beer-xml-type-key impl/beer-xml-integer
-    :description           "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured."
-    :json-schema/example   "3"}))
+    {:type                  :long
+     :spec                  (spec/and int? pos?)
+     impl/beer-xml-type-key impl/beer-xml-integer
+     :description           "A non-negative integer representing the suggested maximum number of times the yeast may be harvested and recultured."
+     :json-schema/example   "3"}))
 
 
 (spec/def ::add-to-secondary
   (st/spec
-   {:spec                  ::prim/boolean
-    impl/beer-xml-type-key impl/beer-xml-boolean
-    :description           (impl/multiline
-                            "A boolean representing if this yeast was added for a secondary fermentation."
-                            "When absent, assume false.")
-    :json-schema/example   "false"
-    :decode/string         impl/decode-boolean
-    :encode/string         impl/encode-boolean}))
+    {:spec                  ::prim/boolean
+     impl/beer-xml-type-key impl/beer-xml-boolean
+     :description           (impl/multiline
+                              "A boolean representing if this yeast was added for a secondary fermentation."
+                              "When absent, assume false.")
+     :json-schema/example   "false"
+     :decode/string         impl/decode-boolean
+     :encode/string         impl/encode-boolean}))
 
 
 (spec/def ::disp-min-temp

--- a/test/common_beer_format/files/xml_test.clj
+++ b/test/common_beer_format/files/xml_test.clj
@@ -1,6 +1,5 @@
 (ns common-beer-format.files.xml-test
   (:require [clj-xml.core :as clj-xml]
-            [clojure.data.xml :as xml]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [com.wallbrew.spoon.spec :as spoon]
@@ -28,7 +27,7 @@
   {:no-doc true}
   [file-name spec]
   (let [xml (deformat (slurp file-name))
-        edn (clj-xml/xml->edn (xml/parse-str xml))]
+        edn (clj-xml/xml-str->edn xml)]
     (cbf/coerce spec edn)))
 
 

--- a/test/common_beer_format/generative/equipment_test.cljc
+++ b/test/common_beer_format/generative/equipment_test.cljc
@@ -1,11 +1,12 @@
 (ns common-beer-format.generative.equipment-test
-  (:require [clojure.spec.alpha :as spec]
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.spec.alpha :as spec]
             [com.wallbrew.spoon.spec :as spoon.spec]
             [common-beer-format.equipment :as equipment]
             [common-beer-format.generative.util :as gen]
-            [common-beer-format.primitives :as primitives]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+            [common-beer-format.impl :as impl]
+            [common-beer-format.primitives :as primitives]))
 
 
 (deftest data-requirement-test
@@ -24,6 +25,38 @@
   (testing "Collection specs may be empty, but must be vectors"
     (is (not (spec/valid? ::equipment/equipments nil)))
     (is (spoon.spec/test-valid? ::equipment/equipments []))))
+
+(deftest wrapper-test
+  (testing "All wrapper specs are marked as such."
+    (is (true? (impl/wrapper-spec? ::equipment/equipment-wrapper)))
+    (is (true? (impl/wrapper-spec? ::equipment/equipments-wrapper))))
+  (testing "All non-wrapper specs are marked as such."
+    (is (false? (impl/wrapper-spec? ::equipment/equipment)))
+    (is (false? (impl/wrapper-spec? ::equipment/equipments)))
+    (is (false? (impl/wrapper-spec? ::equipment/boil-size)))
+    (is (false? (impl/wrapper-spec? ::equipment/batch-size)))
+    (is (false? (impl/wrapper-spec? ::equipment/tun-volume)))
+    (is (false? (impl/wrapper-spec? ::equipment/tun-weight)))
+    (is (false? (impl/wrapper-spec? ::equipment/tun-specific-heat)))
+    (is (false? (impl/wrapper-spec? ::equipment/top-up-water)))
+    (is (false? (impl/wrapper-spec? ::equipment/trub-chiller-loss)))
+    (is (false? (impl/wrapper-spec? ::equipment/evap-rate)))
+    (is (false? (impl/wrapper-spec? ::equipment/boil-time)))
+    (is (false? (impl/wrapper-spec? ::equipment/calc-boil-volume)))
+    (is (false? (impl/wrapper-spec? ::equipment/lauter-deadspace)))
+    (is (false? (impl/wrapper-spec? ::equipment/top-up-kettle)))
+    (is (false? (impl/wrapper-spec? ::equipment/hop-utilization)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-boil-size)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-tun-volume)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-top-up-water)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-trub-chiller-loss)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-lauter-deadspace)))
+    (is (false? (impl/wrapper-spec? ::equipment/display-top-up-kettle)))))
+
+(deftest display-name-test
+  (testing "calc-boil-volume should be named 'Calculate Boil Volume'"
+    (is (= "Calculate Boil Volume"
+           (impl/spec->display-name ::equipment/calc-boil-volume)))))
 
 
 (deftest valid-generators-test

--- a/test/common_beer_format/generative/equipment_test.cljc
+++ b/test/common_beer_format/generative/equipment_test.cljc
@@ -83,6 +83,54 @@
     (is (gen/generatable? ::equipment/equipment))
     (is (gen/generatable? ::equipment/equipment-wrapper))))
 
+(deftest valid-units-test
+  (testing "All records either specify no units key or a valid BeerXML unit type"
+    (is (gen/valid-beer-xml-units? ::equipment/boil-size))
+    (is (gen/valid-beer-xml-units? ::equipment/batch-size))
+    (is (gen/valid-beer-xml-units? ::equipment/tun-volume))
+    (is (gen/valid-beer-xml-units? ::equipment/tun-weight))
+    (is (gen/valid-beer-xml-units? ::equipment/tun-specific-heat))
+    (is (gen/valid-beer-xml-units? ::equipment/top-up-water))
+    (is (gen/valid-beer-xml-units? ::equipment/trub-chiller-loss))
+    (is (gen/valid-beer-xml-units? ::equipment/evap-rate))
+    (is (gen/valid-beer-xml-units? ::equipment/boil-time))
+    (is (gen/valid-beer-xml-units? ::equipment/calc-boil-volume))
+    (is (gen/valid-beer-xml-units? ::equipment/lauter-deadspace))
+    (is (gen/valid-beer-xml-units? ::equipment/top-up-kettle))
+    (is (gen/valid-beer-xml-units? ::equipment/hop-utilization))
+    (is (gen/valid-beer-xml-units? ::equipment/display-boil-size))
+    (is (gen/valid-beer-xml-units? ::equipment/display-tun-volume))
+    (is (gen/valid-beer-xml-units? ::equipment/display-top-up-water))
+    (is (gen/valid-beer-xml-units? ::equipment/display-trub-chiller-loss))
+    (is (gen/valid-beer-xml-units? ::equipment/display-lauter-deadspace))
+    (is (gen/valid-beer-xml-units? ::equipment/display-top-up-kettle))
+    (is (gen/valid-beer-xml-units? ::equipment/equipment))
+    (is (gen/valid-beer-xml-units? ::equipment/equipment-wrapper))))
+
+(deftest valid-type-test
+  (testing "All records either specify no type key or a valid BeerXML type"
+    (is (gen/valid-beer-xml-type? ::equipment/boil-size))
+    (is (gen/valid-beer-xml-type? ::equipment/batch-size))
+    (is (gen/valid-beer-xml-type? ::equipment/tun-volume))
+    (is (gen/valid-beer-xml-type? ::equipment/tun-weight))
+    (is (gen/valid-beer-xml-type? ::equipment/tun-specific-heat))
+    (is (gen/valid-beer-xml-type? ::equipment/top-up-water))
+    (is (gen/valid-beer-xml-type? ::equipment/trub-chiller-loss))
+    (is (gen/valid-beer-xml-type? ::equipment/evap-rate))
+    (is (gen/valid-beer-xml-type? ::equipment/boil-time))
+    (is (gen/valid-beer-xml-type? ::equipment/calc-boil-volume))
+    (is (gen/valid-beer-xml-type? ::equipment/lauter-deadspace))
+    (is (gen/valid-beer-xml-type? ::equipment/top-up-kettle))
+    (is (gen/valid-beer-xml-type? ::equipment/hop-utilization))
+    (is (gen/valid-beer-xml-type? ::equipment/display-boil-size))
+    (is (gen/valid-beer-xml-type? ::equipment/display-tun-volume))
+    (is (gen/valid-beer-xml-type? ::equipment/display-top-up-water))
+    (is (gen/valid-beer-xml-type? ::equipment/display-trub-chiller-loss))
+    (is (gen/valid-beer-xml-type? ::equipment/display-lauter-deadspace))
+    (is (gen/valid-beer-xml-type? ::equipment/display-top-up-kettle))
+    (is (gen/valid-beer-xml-type? ::equipment/equipment))
+    (is (gen/valid-beer-xml-type? ::equipment/equipment-wrapper))))
+
 
 (def sample-equipment
   "A hard-coded sample equipment for static unit tests"

--- a/test/common_beer_format/generative/equipment_test.cljc
+++ b/test/common_beer_format/generative/equipment_test.cljc
@@ -15,7 +15,15 @@
     (is (not (spec/valid? ::equipment/equipment {})))
     (is (not (spec/valid? ::equipment/equipment-wrapper nil)))
     (is (not (spec/valid? ::equipment/equipment-wrapper [])))
-    (is (not (spec/valid? ::equipment/equipment-wrapper {})))))
+    (is (not (spec/valid? ::equipment/equipment-wrapper {})))
+    (is (not (spec/valid? ::equipment/equipments nil)))
+    (is (not (spec/valid? ::equipment/equipments {})))
+    (is (not (spec/valid? ::equipment/equipments-wrapper nil)))
+    (is (not (spec/valid? ::equipment/equipments-wrapper [])))
+    (is (not (spec/valid? ::equipment/equipments-wrapper {}))))
+  (testing "Collection specs may be empty, but must be vectors"
+    (is (not (spec/valid? ::equipment/equipments nil)))
+    (is (spoon.spec/test-valid? ::equipment/equipments []))))
 
 
 (deftest valid-generators-test
@@ -73,7 +81,15 @@
 
 (def sample-equipment-wrapper
   "A hard-coded sample equipment-wrapper for static unit tests"
-  {:equipment sample-equipment})
+  {equipment/equipment sample-equipment})
+
+(def sample-equipments
+  "A hard-coded sample equipments for static unit tests"
+  [sample-equipment-wrapper])
+
+(def sample-equipments-wrapper
+  "A hard-coded sample equipments-wrapper for static unit tests"
+  {equipment/equipments sample-equipments})
 
 
 (deftest static-test-data-check
@@ -81,7 +97,11 @@
     (is (spoon.spec/test-valid? ::equipment/equipment sample-equipment)
         "Static test data should conform to common-beer-format.equipment/equipment")
     (is (spoon.spec/test-valid? ::equipment/equipment-wrapper sample-equipment-wrapper)
-        "Static test data should conform to common-beer-format.equipment/equipment-wrapper")))
+        "Static test data should conform to common-beer-format.equipment/equipment-wrapper")
+    (is (spoon.spec/test-valid? ::equipment/equipments sample-equipments)
+        "Static test data should conform to common-beer-format.equipment/equipments")
+    (is (spoon.spec/test-valid? ::equipment/equipments-wrapper sample-equipments-wrapper)
+        "Static test data should conform to common-beer-format.equipment/equipments-wrapper")))
 
 
 (deftest static-keys-test

--- a/test/common_beer_format/generative/equipment_test.cljc
+++ b/test/common_beer_format/generative/equipment_test.cljc
@@ -83,9 +83,11 @@
   "A hard-coded sample equipment-wrapper for static unit tests"
   {equipment/equipment sample-equipment})
 
+
 (def sample-equipments
   "A hard-coded sample equipments for static unit tests"
   [sample-equipment-wrapper])
+
 
 (def sample-equipments-wrapper
   "A hard-coded sample equipments-wrapper for static unit tests"

--- a/test/common_beer_format/generative/equipment_test.cljc
+++ b/test/common_beer_format/generative/equipment_test.cljc
@@ -26,6 +26,7 @@
     (is (not (spec/valid? ::equipment/equipments nil)))
     (is (spoon.spec/test-valid? ::equipment/equipments []))))
 
+
 (deftest wrapper-test
   (testing "All wrapper specs are marked as such."
     (is (true? (impl/wrapper-spec? ::equipment/equipment-wrapper)))
@@ -52,6 +53,7 @@
     (is (false? (impl/wrapper-spec? ::equipment/display-trub-chiller-loss)))
     (is (false? (impl/wrapper-spec? ::equipment/display-lauter-deadspace)))
     (is (false? (impl/wrapper-spec? ::equipment/display-top-up-kettle)))))
+
 
 (deftest display-name-test
   (testing "calc-boil-volume should be named 'Calculate Boil Volume'"
@@ -83,6 +85,7 @@
     (is (gen/generatable? ::equipment/equipment))
     (is (gen/generatable? ::equipment/equipment-wrapper))))
 
+
 (deftest valid-units-test
   (testing "All records either specify no units key or a valid BeerXML unit type"
     (is (gen/valid-beer-xml-units? ::equipment/boil-size))
@@ -106,6 +109,7 @@
     (is (gen/valid-beer-xml-units? ::equipment/display-top-up-kettle))
     (is (gen/valid-beer-xml-units? ::equipment/equipment))
     (is (gen/valid-beer-xml-units? ::equipment/equipment-wrapper))))
+
 
 (deftest valid-type-test
   (testing "All records either specify no type key or a valid BeerXML type"

--- a/test/common_beer_format/generative/fermentables_test.cljc
+++ b/test/common_beer_format/generative/fermentables_test.cljc
@@ -47,6 +47,7 @@
     (is (gen/generatable? ::fermentables/diastatic-power))
     (is (gen/generatable? ::fermentables/max-in-batch))))
 
+
 (deftest valid-units-test
   (testing "Ensure all specs specify valid units"
     (is (gen/valid-beer-xml-units? ::fermentables/coarse-fine-diff))
@@ -68,6 +69,7 @@
     (is (gen/valid-beer-xml-units? ::fermentables/diastatic-power))
     (is (gen/valid-beer-xml-units? ::fermentables/max-in-batch))))
 
+
 (deftest valid-types-test
   (testing "Ensure all specs specify valid types"
     (is (gen/valid-beer-xml-type? ::fermentables/coarse-fine-diff))
@@ -88,6 +90,7 @@
     (is (gen/valid-beer-xml-type? ::fermentables/add-after-boil))
     (is (gen/valid-beer-xml-type? ::fermentables/diastatic-power))
     (is (gen/valid-beer-xml-type? ::fermentables/max-in-batch))))
+
 
 (deftest wrapper-test
   (testing "Ensure wrapper specs are marked as such"

--- a/test/common_beer_format/generative/fermentables_test.cljc
+++ b/test/common_beer_format/generative/fermentables_test.cljc
@@ -47,6 +47,48 @@
     (is (gen/generatable? ::fermentables/diastatic-power))
     (is (gen/generatable? ::fermentables/max-in-batch))))
 
+(deftest valid-units-test
+  (testing "Ensure all specs specify valid units"
+    (is (gen/valid-beer-xml-units? ::fermentables/coarse-fine-diff))
+    (is (gen/valid-beer-xml-units? ::fermentables/display-color))
+    (is (gen/valid-beer-xml-units? ::fermentables/recommend-mash))
+    (is (gen/valid-beer-xml-units? ::fermentables/protein))
+    (is (gen/valid-beer-xml-units? ::fermentables/yield))
+    (is (gen/valid-beer-xml-units? ::fermentables/ibu-gal-per-lb))
+    (is (gen/valid-beer-xml-units? ::fermentables/fermentables))
+    (is (gen/valid-beer-xml-units? ::fermentables/fermentable-wrapper))
+    (is (gen/valid-beer-xml-units? ::fermentables/potential))
+    (is (gen/valid-beer-xml-units? ::fermentables/supplier))
+    (is (gen/valid-beer-xml-units? ::fermentables/fermentable))
+    (is (gen/valid-beer-xml-units? ::fermentables/type))
+    (is (gen/valid-beer-xml-units? ::fermentables/moisture))
+    (is (gen/valid-beer-xml-units? ::fermentables/fermentables-wrapper))
+    (is (gen/valid-beer-xml-units? ::fermentables/color))
+    (is (gen/valid-beer-xml-units? ::fermentables/add-after-boil))
+    (is (gen/valid-beer-xml-units? ::fermentables/diastatic-power))
+    (is (gen/valid-beer-xml-units? ::fermentables/max-in-batch))))
+
+(deftest valid-types-test
+  (testing "Ensure all specs specify valid types"
+    (is (gen/valid-beer-xml-type? ::fermentables/coarse-fine-diff))
+    (is (gen/valid-beer-xml-type? ::fermentables/display-color))
+    (is (gen/valid-beer-xml-type? ::fermentables/recommend-mash))
+    (is (gen/valid-beer-xml-type? ::fermentables/protein))
+    (is (gen/valid-beer-xml-type? ::fermentables/yield))
+    (is (gen/valid-beer-xml-type? ::fermentables/ibu-gal-per-lb))
+    (is (gen/valid-beer-xml-type? ::fermentables/fermentables))
+    (is (gen/valid-beer-xml-type? ::fermentables/fermentable-wrapper))
+    (is (gen/valid-beer-xml-type? ::fermentables/potential))
+    (is (gen/valid-beer-xml-type? ::fermentables/supplier))
+    (is (gen/valid-beer-xml-type? ::fermentables/fermentable))
+    (is (gen/valid-beer-xml-type? ::fermentables/type))
+    (is (gen/valid-beer-xml-type? ::fermentables/moisture))
+    (is (gen/valid-beer-xml-type? ::fermentables/fermentables-wrapper))
+    (is (gen/valid-beer-xml-type? ::fermentables/color))
+    (is (gen/valid-beer-xml-type? ::fermentables/add-after-boil))
+    (is (gen/valid-beer-xml-type? ::fermentables/diastatic-power))
+    (is (gen/valid-beer-xml-type? ::fermentables/max-in-batch))))
+
 (deftest wrapper-test
   (testing "Ensure wrapper specs are marked as such"
     (is (true? (impl/wrapper-spec? ::fermentables/fermentable-wrapper)))

--- a/test/common_beer_format/generative/fermentables_test.cljc
+++ b/test/common_beer_format/generative/fermentables_test.cljc
@@ -1,11 +1,12 @@
 (ns common-beer-format.generative.fermentables-test
-  (:require [clojure.spec.alpha :as spec]
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.spec.alpha :as spec]
             [com.wallbrew.spoon.spec :as spoon.spec]
             [common-beer-format.fermentables :as fermentables]
             [common-beer-format.generative.util :as gen]
-            [common-beer-format.primitives :as primitives]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+            [common-beer-format.impl :as impl]
+            [common-beer-format.primitives :as primitives]))
 
 
 (deftest data-requirement-test
@@ -45,6 +46,28 @@
     (is (gen/generatable? ::fermentables/add-after-boil))
     (is (gen/generatable? ::fermentables/diastatic-power))
     (is (gen/generatable? ::fermentables/max-in-batch))))
+
+(deftest wrapper-test
+  (testing "Ensure wrapper specs are marked as such"
+    (is (true? (impl/wrapper-spec? ::fermentables/fermentable-wrapper)))
+    (is (true? (impl/wrapper-spec? ::fermentables/fermentables-wrapper))))
+  (testing "Ensure non-wrapper specs are not marked as such"
+    (is (false? (impl/wrapper-spec? ::fermentables/fermentable)))
+    (is (false? (impl/wrapper-spec? ::fermentables/fermentables)))
+    (is (false? (impl/wrapper-spec? ::fermentables/coarse-fine-diff)))
+    (is (false? (impl/wrapper-spec? ::fermentables/display-color)))
+    (is (false? (impl/wrapper-spec? ::fermentables/recommend-mash)))
+    (is (false? (impl/wrapper-spec? ::fermentables/protein)))
+    (is (false? (impl/wrapper-spec? ::fermentables/yield)))
+    (is (false? (impl/wrapper-spec? ::fermentables/ibu-gal-per-lb)))
+    (is (false? (impl/wrapper-spec? ::fermentables/potential)))
+    (is (false? (impl/wrapper-spec? ::fermentables/supplier)))
+    (is (false? (impl/wrapper-spec? ::fermentables/type)))
+    (is (false? (impl/wrapper-spec? ::fermentables/moisture)))
+    (is (false? (impl/wrapper-spec? ::fermentables/color)))
+    (is (false? (impl/wrapper-spec? ::fermentables/add-after-boil)))
+    (is (false? (impl/wrapper-spec? ::fermentables/diastatic-power)))
+    (is (false? (impl/wrapper-spec? ::fermentables/max-in-batch)))))
 
 
 (def sample-fermentable

--- a/test/common_beer_format/generative/hops_test.cljc
+++ b/test/common_beer_format/generative/hops_test.cljc
@@ -44,6 +44,7 @@
     (is (gen/generatable? ::hops/hop))
     (is (gen/generatable? ::hops/alpha))))
 
+
 (deftest wrapper-test
   (testing "Ensure all wrapper specs are marked as such"
     (is (true? (impl/wrapper-spec? ::hops/hops-wrapper)))
@@ -73,197 +74,221 @@
     (is (not (impl/wrapper-spec? ::hops/version)))))
 
 
-    (def sample-hop
-      "A hard-coded sample hop for static unit tests"
-      {:alpha          5.0
-       :amount         0.0638
-       :beta           3.0
-       :caryophyllene  0.0
-       :cohumulone     0.0
-       :display-amount "6.38 g"
-       :display-time   "60.1 min"
-       :form           "Pellet"
-       :hsi            0.0
-       :humulene       0.0
-       :inventory      "0.0 g"
-       :myrcene        0.0
-       :name           "Goldings, East Kent"
-       :notes          "Great all purpose UK hop for ales, stouts, porters"
-       :origin         "United Kingdom"
-       :substitutes    "Fuggles, East Kent Goldings, Target"
-       :time           60.1
-       :type           "Bittering"
-       :use            "Boil"
-       :version        1})
 
 
-    (def sample-hop-wrapper
-      "A hard-coded sample hop-wrapper for static unit tests"
-      {:hop sample-hop})
+
+(def sample-hop
+  "A hard-coded sample hop for static unit tests"
+  {:alpha          5.0
+   :amount         0.0638
+   :beta           3.0
+   :caryophyllene  0.0
+   :cohumulone     0.0
+   :display-amount "6.38 g"
+   :display-time   "60.1 min"
+   :form           "Pellet"
+   :hsi            0.0
+   :humulene       0.0
+   :inventory      "0.0 g"
+   :myrcene        0.0
+   :name           "Goldings, East Kent"
+   :notes          "Great all purpose UK hop for ales, stouts, porters"
+   :origin         "United Kingdom"
+   :substitutes    "Fuggles, East Kent Goldings, Target"
+   :time           60.1
+   :type           "Bittering"
+   :use            "Boil"
+   :version        1})
 
 
-    (def sample-hops
-      "A hard-coded sample hops for static unit tests"
-      [sample-hop-wrapper])
 
 
-    (def sample-hops-wrapper
-      "A hard-coded sample hops-wrapper for static unit tests"
-      {:hops sample-hops})
+
+(def sample-hop-wrapper
+  "A hard-coded sample hop-wrapper for static unit tests"
+  {:hop sample-hop})
 
 
-    (deftest type-test
-      (testing "Ensure type map contains all hop types"
-        (is (contains? hops/hop-types hops/aroma))
-        (is (contains? hops/hop-types hops/bittering))
-        (is (contains? hops/hop-types hops/both)))
-      (testing "Ensure type set only contains known hop types"
-        (is (= #{} (disj hops/hop-types
-                         hops/aroma
-                         hops/bittering
-                         hops/both)))))
 
 
-    (deftest use-test
-      (testing "Ensure type map contains all hop usages"
-        (is (contains? hops/hop-uses hops/boil))
-        (is (contains? hops/hop-uses hops/dry-hop))
-        (is (contains? hops/hop-uses hops/mash))
-        (is (contains? hops/hop-uses hops/first-wort))
-        (is (contains? hops/hop-uses hops/aroma)))
-      (testing "Ensure type set only contains known hop usages"
-        (is (= #{} (disj hops/hop-uses
-                         hops/aroma
-                         hops/boil
-                         hops/dry-hop
-                         hops/first-wort
-                         hops/mash)))))
+
+(def sample-hops
+  "A hard-coded sample hops for static unit tests"
+  [sample-hop-wrapper])
 
 
-    (deftest form-test
-      (testing "Ensure type map contains all hop forms"
-        (is (contains? hops/hop-forms hops/pellet))
-        (is (contains? hops/hop-forms hops/plug))
-        (is (contains? hops/hop-forms hops/leaf)))
-      (testing "Ensure type set only contains known hop forms"
-        (is (= #{} (disj hops/hop-forms
-                         hops/pellet
-                         hops/plug
-                         hops/leaf)))))
 
 
-    (deftest static-keys-test
-      (testing "Ensure all static keys are present"
-        (is (contains? sample-hop hops/alpha)
-            "Static hop must contain alpha key")
-        (is (contains? sample-hop hops/amount)
-            "Static hop must contain amount key")
-        (is (contains? sample-hop hops/beta)
-            "Static hop must contain beta key")
-        (is (contains? sample-hop hops/caryophyllene)
-            "Static hop must contain caryophyllene key")
-        (is (contains? sample-hop hops/cohumulone)
-            "Static hop must contain cohumulone key")
-        (is (contains? sample-hop hops/display-amount)
-            "Static hop must contain display-amount key")
-        (is (contains? sample-hop hops/display-time)
-            "Static hop must contain display-time key")
-        (is (contains? sample-hop hops/form)
-            "Static hop must contain form key")
-        (is (contains? sample-hop hops/hsi)
-            "Static hop must contain hsi key")
-        (is (contains? sample-hop hops/humulene)
-            "Static hop must contain humulene key")
-        (is (contains? sample-hop hops/inventory)
-            "Static hop must contain inventory key")
-        (is (contains? sample-hop hops/myrcene)
-            "Static hop must contain myrcene key")
-        (is (contains? sample-hop hops/name)
-            "Static hop must contain name key")
-        (is (contains? sample-hop hops/notes)
-            "Static hop must contain notes key")
-        (is (contains? sample-hop hops/origin)
-            "Static hop must contain origin key")
-        (is (contains? sample-hop hops/substitutes)
-            "Static hop must contain substitutes key")
-        (is (contains? sample-hop hops/time)
-            "Static hop must contain time key")
-        (is (contains? sample-hop hops/type)
-            "Static hop must contain type key")
-        (is (contains? sample-hop hops/use)
-            "Static hop must contain use key")
-        (is (contains? sample-hop hops/version)
-            "Static hop must contain version key")
-        (is (contains? sample-hop-wrapper hops/hop)
-            "Static hop wrapper must contain hop key")
-        (is (contains? sample-hops-wrapper hops/hops)
-            "Static hops wrapper must contain hops key"))
-      (testing "Ensure all keys in the static hop point to valid data"
-        (is (spec/valid? ::hops/alpha (sample-hop hops/alpha))
-            "Static hop :alpha must be valid")
-        (is (spec/valid? ::primitives/amount (sample-hop hops/amount))
-            "Static hop :amount must be valid")
-        (is (spec/valid? ::hops/beta (sample-hop hops/beta))
-            "Static hop :beta must be valid")
-        (is (spec/valid? ::hops/caryophyllene (sample-hop hops/caryophyllene))
-            "Static hop :caryophyllene must be valid")
-        (is (spec/valid? ::hops/cohumulone (sample-hop hops/cohumulone))
-            "Static hop :cohumulone must be valid")
-        (is (spec/valid? ::primitives/display-amount (sample-hop hops/display-amount))
-            "Static hop :display-amount must be valid")
-        (is (spec/valid? ::primitives/display-time (sample-hop hops/display-time))
-            "Static hop :display-time must be valid")
-        (is (spec/valid? ::hops/form (sample-hop hops/form))
-            "Static hop :form must be valid")
-        (is (spec/valid? ::hops/hsi (sample-hop hops/hsi))
-            "Static hop :hsi must be valid")
-        (is (spec/valid? ::hops/humulene (sample-hop hops/humulene))
-            "Static hop :humulene must be valid")
-        (is (spec/valid? ::primitives/inventory (sample-hop hops/inventory))
-            "Static hop :inventory must be valid")
-        (is (spec/valid? ::hops/myrcene (sample-hop hops/myrcene))
-            "Static hop :myrcene must be valid")
-        (is (spec/valid? ::primitives/name (sample-hop hops/name))
-            "Static hop :name must be valid")
-        (is (spec/valid? ::primitives/notes (sample-hop hops/notes))
-            "Static hop :notes must be valid")
-        (is (spec/valid? ::primitives/origin (sample-hop hops/origin))
-            "Static hop :origin must be valid")
-        (is (spec/valid? ::primitives/substitutes (sample-hop hops/substitutes))
-            "Static hop :substitutes must be valid")
-        (is (spec/valid? ::hops/time (sample-hop hops/time))
-            "Static hop :time must be valid")
-        (is (spec/valid? ::hops/type (sample-hop hops/type))
-            "Static hop :type must be valid")
-        (is (spec/valid? ::hops/use (sample-hop hops/use))
-            "Static hop :use must be valid")
-        (is (spec/valid? ::primitives/version (sample-hop hops/version))
-            "Static hop :version must be valid")
-        (is (spec/valid? ::hops/hop (sample-hop-wrapper hops/hop))
-            "Static hop wrapper :hop must be valid")
-        (is (spec/valid? ::hops/hops (sample-hops-wrapper hops/hops))
-            "Static hops wrapper :hops must be valid"))
-      (testing "Sample hops should only contain valid keys"
-        (is (= {} (dissoc sample-hop
-                          hops/alpha
-                          hops/amount
-                          hops/beta
-                          hops/caryophyllene
-                          hops/cohumulone
-                          hops/display-amount
-                          hops/display-time
-                          hops/form
-                          hops/hsi
-                          hops/humulene
-                          hops/inventory
-                          hops/myrcene
-                          hops/name
-                          hops/notes
-                          hops/origin
-                          hops/substitutes
-                          hops/time
-                          hops/type
-                          hops/use
-                          hops/version)))
-        (is (= {} (dissoc sample-hop-wrapper hops/hop)))
-        (is (= {} (dissoc sample-hops-wrapper hops/hops)))))
+
+(def sample-hops-wrapper
+  "A hard-coded sample hops-wrapper for static unit tests"
+  {:hops sample-hops})
+
+
+
+
+
+(deftest type-test
+  (testing "Ensure type map contains all hop types"
+    (is (contains? hops/hop-types hops/aroma))
+    (is (contains? hops/hop-types hops/bittering))
+    (is (contains? hops/hop-types hops/both)))
+  (testing "Ensure type set only contains known hop types"
+    (is (= #{} (disj hops/hop-types
+                     hops/aroma
+                     hops/bittering
+                     hops/both)))))
+
+
+
+
+
+(deftest use-test
+  (testing "Ensure type map contains all hop usages"
+    (is (contains? hops/hop-uses hops/boil))
+    (is (contains? hops/hop-uses hops/dry-hop))
+    (is (contains? hops/hop-uses hops/mash))
+    (is (contains? hops/hop-uses hops/first-wort))
+    (is (contains? hops/hop-uses hops/aroma)))
+  (testing "Ensure type set only contains known hop usages"
+    (is (= #{} (disj hops/hop-uses
+                     hops/aroma
+                     hops/boil
+                     hops/dry-hop
+                     hops/first-wort
+                     hops/mash)))))
+
+
+
+
+
+(deftest form-test
+  (testing "Ensure type map contains all hop forms"
+    (is (contains? hops/hop-forms hops/pellet))
+    (is (contains? hops/hop-forms hops/plug))
+    (is (contains? hops/hop-forms hops/leaf)))
+  (testing "Ensure type set only contains known hop forms"
+    (is (= #{} (disj hops/hop-forms
+                     hops/pellet
+                     hops/plug
+                     hops/leaf)))))
+
+
+
+
+
+(deftest static-keys-test
+  (testing "Ensure all static keys are present"
+    (is (contains? sample-hop hops/alpha)
+        "Static hop must contain alpha key")
+    (is (contains? sample-hop hops/amount)
+        "Static hop must contain amount key")
+    (is (contains? sample-hop hops/beta)
+        "Static hop must contain beta key")
+    (is (contains? sample-hop hops/caryophyllene)
+        "Static hop must contain caryophyllene key")
+    (is (contains? sample-hop hops/cohumulone)
+        "Static hop must contain cohumulone key")
+    (is (contains? sample-hop hops/display-amount)
+        "Static hop must contain display-amount key")
+    (is (contains? sample-hop hops/display-time)
+        "Static hop must contain display-time key")
+    (is (contains? sample-hop hops/form)
+        "Static hop must contain form key")
+    (is (contains? sample-hop hops/hsi)
+        "Static hop must contain hsi key")
+    (is (contains? sample-hop hops/humulene)
+        "Static hop must contain humulene key")
+    (is (contains? sample-hop hops/inventory)
+        "Static hop must contain inventory key")
+    (is (contains? sample-hop hops/myrcene)
+        "Static hop must contain myrcene key")
+    (is (contains? sample-hop hops/name)
+        "Static hop must contain name key")
+    (is (contains? sample-hop hops/notes)
+        "Static hop must contain notes key")
+    (is (contains? sample-hop hops/origin)
+        "Static hop must contain origin key")
+    (is (contains? sample-hop hops/substitutes)
+        "Static hop must contain substitutes key")
+    (is (contains? sample-hop hops/time)
+        "Static hop must contain time key")
+    (is (contains? sample-hop hops/type)
+        "Static hop must contain type key")
+    (is (contains? sample-hop hops/use)
+        "Static hop must contain use key")
+    (is (contains? sample-hop hops/version)
+        "Static hop must contain version key")
+    (is (contains? sample-hop-wrapper hops/hop)
+        "Static hop wrapper must contain hop key")
+    (is (contains? sample-hops-wrapper hops/hops)
+        "Static hops wrapper must contain hops key"))
+  (testing "Ensure all keys in the static hop point to valid data"
+    (is (spec/valid? ::hops/alpha (sample-hop hops/alpha))
+        "Static hop :alpha must be valid")
+    (is (spec/valid? ::primitives/amount (sample-hop hops/amount))
+        "Static hop :amount must be valid")
+    (is (spec/valid? ::hops/beta (sample-hop hops/beta))
+        "Static hop :beta must be valid")
+    (is (spec/valid? ::hops/caryophyllene (sample-hop hops/caryophyllene))
+        "Static hop :caryophyllene must be valid")
+    (is (spec/valid? ::hops/cohumulone (sample-hop hops/cohumulone))
+        "Static hop :cohumulone must be valid")
+    (is (spec/valid? ::primitives/display-amount (sample-hop hops/display-amount))
+        "Static hop :display-amount must be valid")
+    (is (spec/valid? ::primitives/display-time (sample-hop hops/display-time))
+        "Static hop :display-time must be valid")
+    (is (spec/valid? ::hops/form (sample-hop hops/form))
+        "Static hop :form must be valid")
+    (is (spec/valid? ::hops/hsi (sample-hop hops/hsi))
+        "Static hop :hsi must be valid")
+    (is (spec/valid? ::hops/humulene (sample-hop hops/humulene))
+        "Static hop :humulene must be valid")
+    (is (spec/valid? ::primitives/inventory (sample-hop hops/inventory))
+        "Static hop :inventory must be valid")
+    (is (spec/valid? ::hops/myrcene (sample-hop hops/myrcene))
+        "Static hop :myrcene must be valid")
+    (is (spec/valid? ::primitives/name (sample-hop hops/name))
+        "Static hop :name must be valid")
+    (is (spec/valid? ::primitives/notes (sample-hop hops/notes))
+        "Static hop :notes must be valid")
+    (is (spec/valid? ::primitives/origin (sample-hop hops/origin))
+        "Static hop :origin must be valid")
+    (is (spec/valid? ::primitives/substitutes (sample-hop hops/substitutes))
+        "Static hop :substitutes must be valid")
+    (is (spec/valid? ::hops/time (sample-hop hops/time))
+        "Static hop :time must be valid")
+    (is (spec/valid? ::hops/type (sample-hop hops/type))
+        "Static hop :type must be valid")
+    (is (spec/valid? ::hops/use (sample-hop hops/use))
+        "Static hop :use must be valid")
+    (is (spec/valid? ::primitives/version (sample-hop hops/version))
+        "Static hop :version must be valid")
+    (is (spec/valid? ::hops/hop (sample-hop-wrapper hops/hop))
+        "Static hop wrapper :hop must be valid")
+    (is (spec/valid? ::hops/hops (sample-hops-wrapper hops/hops))
+        "Static hops wrapper :hops must be valid"))
+  (testing "Sample hops should only contain valid keys"
+    (is (= {} (dissoc sample-hop
+                      hops/alpha
+                      hops/amount
+                      hops/beta
+                      hops/caryophyllene
+                      hops/cohumulone
+                      hops/display-amount
+                      hops/display-time
+                      hops/form
+                      hops/hsi
+                      hops/humulene
+                      hops/inventory
+                      hops/myrcene
+                      hops/name
+                      hops/notes
+                      hops/origin
+                      hops/substitutes
+                      hops/time
+                      hops/type
+                      hops/use
+                      hops/version)))
+    (is (= {} (dissoc sample-hop-wrapper hops/hop)))
+    (is (= {} (dissoc sample-hops-wrapper hops/hops)))))

--- a/test/common_beer_format/generative/hops_test.cljc
+++ b/test/common_beer_format/generative/hops_test.cljc
@@ -1,11 +1,12 @@
 (ns common-beer-format.generative.hops-test
-  (:require [clojure.spec.alpha :as spec]
+  (:require #? (:clj  [clojure.test :refer [deftest is testing]])
+            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.spec.alpha :as spec]
             [com.wallbrew.spoon.spec :as spoon.spec]
             [common-beer-format.generative.util :as gen]
             [common-beer-format.hops :as hops]
-            [common-beer-format.primitives :as primitives]
-            #? (:clj  [clojure.test :refer [deftest is testing]])
-            #? (:cljs [cljs.test    :refer-macros [deftest is testing]])))
+            [common-beer-format.impl :as impl]
+            [common-beer-format.primitives :as primitives]))
 
 
 (deftest data-requirement-test
@@ -43,198 +44,226 @@
     (is (gen/generatable? ::hops/hop))
     (is (gen/generatable? ::hops/alpha))))
 
-
-(def sample-hop
-  "A hard-coded sample hop for static unit tests"
-  {:alpha          5.0
-   :amount         0.0638
-   :beta           3.0
-   :caryophyllene  0.0
-   :cohumulone     0.0
-   :display-amount "6.38 g"
-   :display-time   "60.1 min"
-   :form           "pellet"
-   :hsi            0.0
-   :humulene       0.0
-   :inventory      "0.0 g"
-   :myrcene        0.0
-   :name           "Goldings, East Kent"
-   :notes          "Great all purpose UK hop for ales, stouts, porters"
-   :origin         "United Kingdom"
-   :substitutes    "Fuggles, East Kent Goldings, Target"
-   :time           60.1
-   :type           "bittering"
-   :use            "Boil"
-   :version        1})
-
-
-(def sample-hop-wrapper
-  "A hard-coded sample hop-wrapper for static unit tests"
-  {:hop sample-hop})
-
-
-(def sample-hops
-  "A hard-coded sample hops for static unit tests"
-  [sample-hop-wrapper])
+(deftest wrapper-test
+  (testing "Ensure all wrapper specs are marked as such"
+    (is (true? (impl/wrapper-spec? ::hops/hops-wrapper)))
+    (is (true? (impl/wrapper-spec? ::hops/hop-wrapper))))
+  (testing "Ensure all non-wrapper specs are not marked as such"
+    (is (not (impl/wrapper-spec? ::hops/hops)))
+    (is (not (impl/wrapper-spec? ::hops/hop)))
+    (is (not (impl/wrapper-spec? ::hops/alpha)))
+    (is (not (impl/wrapper-spec? ::hops/amount)))
+    (is (not (impl/wrapper-spec? ::hops/beta)))
+    (is (not (impl/wrapper-spec? ::hops/caryophyllene)))
+    (is (not (impl/wrapper-spec? ::hops/cohumulone)))
+    (is (not (impl/wrapper-spec? ::hops/display-amount)))
+    (is (not (impl/wrapper-spec? ::hops/display-time)))
+    (is (not (impl/wrapper-spec? ::hops/form)))
+    (is (not (impl/wrapper-spec? ::hops/hsi)))
+    (is (not (impl/wrapper-spec? ::hops/humulene)))
+    (is (not (impl/wrapper-spec? ::hops/inventory)))
+    (is (not (impl/wrapper-spec? ::hops/myrcene)))
+    (is (not (impl/wrapper-spec? ::hops/name)))
+    (is (not (impl/wrapper-spec? ::hops/notes)))
+    (is (not (impl/wrapper-spec? ::hops/origin)))
+    (is (not (impl/wrapper-spec? ::hops/substitutes)))
+    (is (not (impl/wrapper-spec? ::hops/time)))
+    (is (not (impl/wrapper-spec? ::hops/type)))
+    (is (not (impl/wrapper-spec? ::hops/use)))
+    (is (not (impl/wrapper-spec? ::hops/version)))))
 
 
-(def sample-hops-wrapper
-  "A hard-coded sample hops-wrapper for static unit tests"
-  {:hops sample-hops})
+    (def sample-hop
+      "A hard-coded sample hop for static unit tests"
+      {:alpha          5.0
+       :amount         0.0638
+       :beta           3.0
+       :caryophyllene  0.0
+       :cohumulone     0.0
+       :display-amount "6.38 g"
+       :display-time   "60.1 min"
+       :form           "Pellet"
+       :hsi            0.0
+       :humulene       0.0
+       :inventory      "0.0 g"
+       :myrcene        0.0
+       :name           "Goldings, East Kent"
+       :notes          "Great all purpose UK hop for ales, stouts, porters"
+       :origin         "United Kingdom"
+       :substitutes    "Fuggles, East Kent Goldings, Target"
+       :time           60.1
+       :type           "Bittering"
+       :use            "Boil"
+       :version        1})
 
 
-(deftest type-test
-  (testing "Ensure type map contains all hop types"
-    (is (contains? hops/hop-types hops/aroma))
-    (is (contains? hops/hop-types hops/bittering))
-    (is (contains? hops/hop-types hops/both)))
-  (testing "Ensure type set only contains known hop types"
-    (is (= #{} (disj hops/hop-types
-                     hops/aroma
-                     hops/bittering
-                     hops/both)))))
+    (def sample-hop-wrapper
+      "A hard-coded sample hop-wrapper for static unit tests"
+      {:hop sample-hop})
 
 
-(deftest use-test
-  (testing "Ensure type map contains all hop usages"
-    (is (contains? hops/hop-uses hops/boil))
-    (is (contains? hops/hop-uses hops/dry-hop))
-    (is (contains? hops/hop-uses hops/mash))
-    (is (contains? hops/hop-uses hops/first-wort))
-    (is (contains? hops/hop-uses hops/aroma)))
-  (testing "Ensure type set only contains known hop usages"
-    (is (= #{} (disj hops/hop-uses
-                     hops/aroma
-                     hops/boil
-                     hops/dry-hop
-                     hops/first-wort
-                     hops/mash)))))
+    (def sample-hops
+      "A hard-coded sample hops for static unit tests"
+      [sample-hop-wrapper])
 
 
-(deftest form-test
-  (testing "Ensure type map contains all hop forms"
-    (is (contains? hops/hop-forms hops/pellet))
-    (is (contains? hops/hop-forms hops/plug))
-    (is (contains? hops/hop-forms hops/leaf)))
-  (testing "Ensure type set only contains known hop forms"
-    (is (= #{} (disj hops/hop-forms
-                     hops/pellet
-                     hops/plug
-                     hops/leaf)))))
+    (def sample-hops-wrapper
+      "A hard-coded sample hops-wrapper for static unit tests"
+      {:hops sample-hops})
 
 
-(deftest static-keys-test
-  (testing "Ensure all static keys are present"
-    (is (contains? sample-hop hops/alpha)
-        "Static hop must contain alpha key")
-    (is (contains? sample-hop hops/amount)
-        "Static hop must contain amount key")
-    (is (contains? sample-hop hops/beta)
-        "Static hop must contain beta key")
-    (is (contains? sample-hop hops/caryophyllene)
-        "Static hop must contain caryophyllene key")
-    (is (contains? sample-hop hops/cohumulone)
-        "Static hop must contain cohumulone key")
-    (is (contains? sample-hop hops/display-amount)
-        "Static hop must contain display-amount key")
-    (is (contains? sample-hop hops/display-time)
-        "Static hop must contain display-time key")
-    (is (contains? sample-hop hops/form)
-        "Static hop must contain form key")
-    (is (contains? sample-hop hops/hsi)
-        "Static hop must contain hsi key")
-    (is (contains? sample-hop hops/humulene)
-        "Static hop must contain humulene key")
-    (is (contains? sample-hop hops/inventory)
-        "Static hop must contain inventory key")
-    (is (contains? sample-hop hops/myrcene)
-        "Static hop must contain myrcene key")
-    (is (contains? sample-hop hops/name)
-        "Static hop must contain name key")
-    (is (contains? sample-hop hops/notes)
-        "Static hop must contain notes key")
-    (is (contains? sample-hop hops/origin)
-        "Static hop must contain origin key")
-    (is (contains? sample-hop hops/substitutes)
-        "Static hop must contain substitutes key")
-    (is (contains? sample-hop hops/time)
-        "Static hop must contain time key")
-    (is (contains? sample-hop hops/type)
-        "Static hop must contain type key")
-    (is (contains? sample-hop hops/use)
-        "Static hop must contain use key")
-    (is (contains? sample-hop hops/version)
-        "Static hop must contain version key")
-    (is (contains? sample-hop-wrapper hops/hop)
-        "Static hop wrapper must contain hop key")
-    (is (contains? sample-hops-wrapper hops/hops)
-        "Static hops wrapper must contain hops key"))
-  (testing "Ensure all keys in the static hop point to valid data"
-    (is (spec/valid? ::hops/alpha (sample-hop hops/alpha))
-        "Static hop :alpha must be valid")
-    (is (spec/valid? ::primitives/amount (sample-hop hops/amount))
-        "Static hop :amount must be valid")
-    (is (spec/valid? ::hops/beta (sample-hop hops/beta))
-        "Static hop :beta must be valid")
-    (is (spec/valid? ::hops/caryophyllene (sample-hop hops/caryophyllene))
-        "Static hop :caryophyllene must be valid")
-    (is (spec/valid? ::hops/cohumulone (sample-hop hops/cohumulone))
-        "Static hop :cohumulone must be valid")
-    (is (spec/valid? ::primitives/display-amount (sample-hop hops/display-amount))
-        "Static hop :display-amount must be valid")
-    (is (spec/valid? ::primitives/display-time (sample-hop hops/display-time))
-        "Static hop :display-time must be valid")
-    (is (spec/valid? ::hops/form (sample-hop hops/form))
-        "Static hop :form must be valid")
-    (is (spec/valid? ::hops/hsi (sample-hop hops/hsi))
-        "Static hop :hsi must be valid")
-    (is (spec/valid? ::hops/humulene (sample-hop hops/humulene))
-        "Static hop :humulene must be valid")
-    (is (spec/valid? ::primitives/inventory (sample-hop hops/inventory))
-        "Static hop :inventory must be valid")
-    (is (spec/valid? ::hops/myrcene (sample-hop hops/myrcene))
-        "Static hop :myrcene must be valid")
-    (is (spec/valid? ::primitives/name (sample-hop hops/name))
-        "Static hop :name must be valid")
-    (is (spec/valid? ::primitives/notes (sample-hop hops/notes))
-        "Static hop :notes must be valid")
-    (is (spec/valid? ::primitives/origin (sample-hop hops/origin))
-        "Static hop :origin must be valid")
-    (is (spec/valid? ::primitives/substitutes (sample-hop hops/substitutes))
-        "Static hop :substitutes must be valid")
-    (is (spec/valid? ::hops/time (sample-hop hops/time))
-        "Static hop :time must be valid")
-    (is (spec/valid? ::hops/type (sample-hop hops/type))
-        "Static hop :type must be valid")
-    (is (spec/valid? ::hops/use (sample-hop hops/use))
-        "Static hop :use must be valid")
-    (is (spec/valid? ::primitives/version (sample-hop hops/version))
-        "Static hop :version must be valid")
-    (is (spec/valid? ::hops/hop (sample-hop-wrapper hops/hop))
-        "Static hop wrapper :hop must be valid")
-    (is (spec/valid? ::hops/hops (sample-hops-wrapper hops/hops))
-        "Static hops wrapper :hops must be valid"))
-  (testing "Sample hops should only contain valid keys"
-    (is (= {} (dissoc sample-hop
-                      hops/alpha
-                      hops/amount
-                      hops/beta
-                      hops/caryophyllene
-                      hops/cohumulone
-                      hops/display-amount
-                      hops/display-time
-                      hops/form
-                      hops/hsi
-                      hops/humulene
-                      hops/inventory
-                      hops/myrcene
-                      hops/name
-                      hops/notes
-                      hops/origin
-                      hops/substitutes
-                      hops/time
-                      hops/type
-                      hops/use
-                      hops/version)))
-    (is (= {} (dissoc sample-hop-wrapper hops/hop)))
-    (is (= {} (dissoc sample-hops-wrapper hops/hops)))))
+    (deftest type-test
+      (testing "Ensure type map contains all hop types"
+        (is (contains? hops/hop-types hops/aroma))
+        (is (contains? hops/hop-types hops/bittering))
+        (is (contains? hops/hop-types hops/both)))
+      (testing "Ensure type set only contains known hop types"
+        (is (= #{} (disj hops/hop-types
+                         hops/aroma
+                         hops/bittering
+                         hops/both)))))
+
+
+    (deftest use-test
+      (testing "Ensure type map contains all hop usages"
+        (is (contains? hops/hop-uses hops/boil))
+        (is (contains? hops/hop-uses hops/dry-hop))
+        (is (contains? hops/hop-uses hops/mash))
+        (is (contains? hops/hop-uses hops/first-wort))
+        (is (contains? hops/hop-uses hops/aroma)))
+      (testing "Ensure type set only contains known hop usages"
+        (is (= #{} (disj hops/hop-uses
+                         hops/aroma
+                         hops/boil
+                         hops/dry-hop
+                         hops/first-wort
+                         hops/mash)))))
+
+
+    (deftest form-test
+      (testing "Ensure type map contains all hop forms"
+        (is (contains? hops/hop-forms hops/pellet))
+        (is (contains? hops/hop-forms hops/plug))
+        (is (contains? hops/hop-forms hops/leaf)))
+      (testing "Ensure type set only contains known hop forms"
+        (is (= #{} (disj hops/hop-forms
+                         hops/pellet
+                         hops/plug
+                         hops/leaf)))))
+
+
+    (deftest static-keys-test
+      (testing "Ensure all static keys are present"
+        (is (contains? sample-hop hops/alpha)
+            "Static hop must contain alpha key")
+        (is (contains? sample-hop hops/amount)
+            "Static hop must contain amount key")
+        (is (contains? sample-hop hops/beta)
+            "Static hop must contain beta key")
+        (is (contains? sample-hop hops/caryophyllene)
+            "Static hop must contain caryophyllene key")
+        (is (contains? sample-hop hops/cohumulone)
+            "Static hop must contain cohumulone key")
+        (is (contains? sample-hop hops/display-amount)
+            "Static hop must contain display-amount key")
+        (is (contains? sample-hop hops/display-time)
+            "Static hop must contain display-time key")
+        (is (contains? sample-hop hops/form)
+            "Static hop must contain form key")
+        (is (contains? sample-hop hops/hsi)
+            "Static hop must contain hsi key")
+        (is (contains? sample-hop hops/humulene)
+            "Static hop must contain humulene key")
+        (is (contains? sample-hop hops/inventory)
+            "Static hop must contain inventory key")
+        (is (contains? sample-hop hops/myrcene)
+            "Static hop must contain myrcene key")
+        (is (contains? sample-hop hops/name)
+            "Static hop must contain name key")
+        (is (contains? sample-hop hops/notes)
+            "Static hop must contain notes key")
+        (is (contains? sample-hop hops/origin)
+            "Static hop must contain origin key")
+        (is (contains? sample-hop hops/substitutes)
+            "Static hop must contain substitutes key")
+        (is (contains? sample-hop hops/time)
+            "Static hop must contain time key")
+        (is (contains? sample-hop hops/type)
+            "Static hop must contain type key")
+        (is (contains? sample-hop hops/use)
+            "Static hop must contain use key")
+        (is (contains? sample-hop hops/version)
+            "Static hop must contain version key")
+        (is (contains? sample-hop-wrapper hops/hop)
+            "Static hop wrapper must contain hop key")
+        (is (contains? sample-hops-wrapper hops/hops)
+            "Static hops wrapper must contain hops key"))
+      (testing "Ensure all keys in the static hop point to valid data"
+        (is (spec/valid? ::hops/alpha (sample-hop hops/alpha))
+            "Static hop :alpha must be valid")
+        (is (spec/valid? ::primitives/amount (sample-hop hops/amount))
+            "Static hop :amount must be valid")
+        (is (spec/valid? ::hops/beta (sample-hop hops/beta))
+            "Static hop :beta must be valid")
+        (is (spec/valid? ::hops/caryophyllene (sample-hop hops/caryophyllene))
+            "Static hop :caryophyllene must be valid")
+        (is (spec/valid? ::hops/cohumulone (sample-hop hops/cohumulone))
+            "Static hop :cohumulone must be valid")
+        (is (spec/valid? ::primitives/display-amount (sample-hop hops/display-amount))
+            "Static hop :display-amount must be valid")
+        (is (spec/valid? ::primitives/display-time (sample-hop hops/display-time))
+            "Static hop :display-time must be valid")
+        (is (spec/valid? ::hops/form (sample-hop hops/form))
+            "Static hop :form must be valid")
+        (is (spec/valid? ::hops/hsi (sample-hop hops/hsi))
+            "Static hop :hsi must be valid")
+        (is (spec/valid? ::hops/humulene (sample-hop hops/humulene))
+            "Static hop :humulene must be valid")
+        (is (spec/valid? ::primitives/inventory (sample-hop hops/inventory))
+            "Static hop :inventory must be valid")
+        (is (spec/valid? ::hops/myrcene (sample-hop hops/myrcene))
+            "Static hop :myrcene must be valid")
+        (is (spec/valid? ::primitives/name (sample-hop hops/name))
+            "Static hop :name must be valid")
+        (is (spec/valid? ::primitives/notes (sample-hop hops/notes))
+            "Static hop :notes must be valid")
+        (is (spec/valid? ::primitives/origin (sample-hop hops/origin))
+            "Static hop :origin must be valid")
+        (is (spec/valid? ::primitives/substitutes (sample-hop hops/substitutes))
+            "Static hop :substitutes must be valid")
+        (is (spec/valid? ::hops/time (sample-hop hops/time))
+            "Static hop :time must be valid")
+        (is (spec/valid? ::hops/type (sample-hop hops/type))
+            "Static hop :type must be valid")
+        (is (spec/valid? ::hops/use (sample-hop hops/use))
+            "Static hop :use must be valid")
+        (is (spec/valid? ::primitives/version (sample-hop hops/version))
+            "Static hop :version must be valid")
+        (is (spec/valid? ::hops/hop (sample-hop-wrapper hops/hop))
+            "Static hop wrapper :hop must be valid")
+        (is (spec/valid? ::hops/hops (sample-hops-wrapper hops/hops))
+            "Static hops wrapper :hops must be valid"))
+      (testing "Sample hops should only contain valid keys"
+        (is (= {} (dissoc sample-hop
+                          hops/alpha
+                          hops/amount
+                          hops/beta
+                          hops/caryophyllene
+                          hops/cohumulone
+                          hops/display-amount
+                          hops/display-time
+                          hops/form
+                          hops/hsi
+                          hops/humulene
+                          hops/inventory
+                          hops/myrcene
+                          hops/name
+                          hops/notes
+                          hops/origin
+                          hops/substitutes
+                          hops/time
+                          hops/type
+                          hops/use
+                          hops/version)))
+        (is (= {} (dissoc sample-hop-wrapper hops/hop)))
+        (is (= {} (dissoc sample-hops-wrapper hops/hops)))))

--- a/test/common_beer_format/generative/hops_test.cljc
+++ b/test/common_beer_format/generative/hops_test.cljc
@@ -74,9 +74,6 @@
     (is (not (impl/wrapper-spec? ::hops/version)))))
 
 
-
-
-
 (def sample-hop
   "A hard-coded sample hop for static unit tests"
   {:alpha          5.0
@@ -101,15 +98,9 @@
    :version        1})
 
 
-
-
-
 (def sample-hop-wrapper
   "A hard-coded sample hop-wrapper for static unit tests"
   {:hop sample-hop})
-
-
-
 
 
 (def sample-hops
@@ -117,15 +108,9 @@
   [sample-hop-wrapper])
 
 
-
-
-
 (def sample-hops-wrapper
   "A hard-coded sample hops-wrapper for static unit tests"
   {:hops sample-hops})
-
-
-
 
 
 (deftest type-test
@@ -138,9 +123,6 @@
                      hops/aroma
                      hops/bittering
                      hops/both)))))
-
-
-
 
 
 (deftest use-test
@@ -159,9 +141,6 @@
                      hops/mash)))))
 
 
-
-
-
 (deftest form-test
   (testing "Ensure type map contains all hop forms"
     (is (contains? hops/hop-forms hops/pellet))
@@ -172,9 +151,6 @@
                      hops/pellet
                      hops/plug
                      hops/leaf)))))
-
-
-
 
 
 (deftest static-keys-test

--- a/test/common_beer_format/generative/mash_test.cljc
+++ b/test/common_beer_format/generative/mash_test.cljc
@@ -113,6 +113,14 @@
   "A hard-coded sample mash-wrapper for static unit tests"
   {:mash sample-mash})
 
+(def sample-mashs
+  "A hard-coded sample mashs for static unit tests"
+  [sample-mash-wrapper])
+
+(def sample-mashs-wrapper
+  "A hard-coded sample mashs-wrapper for static unit tests"
+  {:mashs sample-mashs})
+
 
 (deftest mash-step-type-test
   (testing "Ensure type map contains all mash step types"
@@ -137,7 +145,11 @@
     (is (spoon.spec/test-valid? ::mash/mash sample-mash)
         "Static test data should conform to common-beer-format.hop/mash")
     (is (spoon.spec/test-valid? ::mash/mash-wrapper sample-mash-wrapper)
-        "Static test data should conform to common-beer-format.hop/mash-wrapper")))
+        "Static test data should conform to common-beer-format.hop/mash-wrapper")
+    (is (spoon.spec/test-valid? ::mash/mashs sample-mashs)
+        "Static test data should conform to common-beer-format.hop/mashs")
+    (is (spoon.spec/test-valid? ::mash/mashs-wrapper sample-mashs-wrapper)
+        "Static test data should conform to common-beer-format.hop/mashs-wrapper")))
 
 
 (deftest static-keys-test

--- a/test/common_beer_format/generative/mash_test.cljc
+++ b/test/common_beer_format/generative/mash_test.cljc
@@ -113,9 +113,11 @@
   "A hard-coded sample mash-wrapper for static unit tests"
   {:mash sample-mash})
 
+
 (def sample-mashs
   "A hard-coded sample mashs for static unit tests"
   [sample-mash-wrapper])
+
 
 (def sample-mashs-wrapper
   "A hard-coded sample mashs-wrapper for static unit tests"

--- a/test/common_beer_format/generative/util.cljc
+++ b/test/common_beer_format/generative/util.cljc
@@ -18,6 +18,7 @@
       (println e)
       false)))
 
+
 (defn valid-beer-xml-units?
   "Check the spec for valid BeerXML units.
    Values must either not be present or be one of the valid BeerXML units."
@@ -30,6 +31,7 @@
       (string? spec-units) (contains? impl/beer-xml-units spec-units)
       (coll? spec-units)   (every? #(contains? impl/beer-xml-units %) spec-units)
       :else                (do (println (str "Invalid units specified for spec: " spec)) false))))
+
 
 (defn valid-beer-xml-type?
   "Check the spec for valid BeerXML types.

--- a/test/common_beer_format/generative/util.cljc
+++ b/test/common_beer_format/generative/util.cljc
@@ -1,7 +1,9 @@
 (ns common-beer-format.generative.util
   "Utilities for generative tests"
   (:require [clojure.spec.alpha :as spec]
-            [clojure.spec.gen.alpha :as gen]))
+            [clojure.spec.gen.alpha :as gen]
+            [common-beer-format.core :as cbf]
+            [common-beer-format.impl :as impl]))
 
 
 (defn generatable?
@@ -15,3 +17,28 @@
       (println (str "Failed to generate a value for spec: " spec))
       (println e)
       false)))
+
+(defn valid-beer-xml-units?
+  "Check the spec for valid BeerXML units.
+   Values must either not be present or be one of the valid BeerXML units."
+  {:added  "2.3"
+   :no-doc true}
+  [spec]
+  (let [spec-units (-> spec cbf/get-spec impl/beer-xml-units-key)]
+    (cond
+      (nil? spec-units)    (do (println (str "No units specified for spec: " spec)) true)
+      (string? spec-units) (contains? impl/beer-xml-units spec-units)
+      (coll? spec-units)   (every? #(contains? impl/beer-xml-units %) spec-units)
+      :else                (do (println (str "Invalid units specified for spec: " spec)) false))))
+
+(defn valid-beer-xml-type?
+  "Check the spec for valid BeerXML types.
+   Values must either not be present or be one of the valid BeerXML types."
+  {:added  "2.3"
+   :no-doc true}
+  [spec]
+  (let [spec-units (-> spec cbf/get-spec impl/beer-xml-type-key)]
+    (cond
+      (nil? spec-units)    (do (println (str "No type specified for spec: " spec)) true)
+      (string? spec-units) (contains? impl/beer-xml-types spec-units)
+      :else                (do (println (str "Invalid type specified for spec: " spec)) false))))


### PR DESCRIPTION
# Proposed Changes

* Added
  * Documentation generation from specs to markdown.
* Changed
  * Specs now carry metadata indicating the BeerXML Types and Units they are associated with.
  * Specs may contain metadata to render human friendly names for abbreviated fields.
  * List specs are tightened to only allow valid BeerXML units and types.
  * Symbols have been added for all legal values for BeerXML List types. For example: `common-beer-format.miscs/boil`.
* Removed
  * Data (de)serialization dependencies (`clojure.data.xml`, `clojure.data.json`) leftover from `clj-xml`'s promotion to a standalone library have been removed.
  * Data generation dependencies (`clojure.test.check`) have been removed.

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
